### PR TITLE
Add sample_label_size initialisation

### DIFF
--- a/connectomics/data/dataset/dataset_volume.py
+++ b/connectomics/data/dataset/dataset_volume.py
@@ -33,7 +33,7 @@ class VolumeDataset(torch.utils.data.Dataset):
         self.input = volume
         self.label = label
         self.augmentor = augmentor  # data augmentation
-
+        self.sample_label_size = sample_label_size #Output Size
         self.target_opt = target_opt  # target opt
         self.weight_opt = weight_opt  # loss opt 
 


### PR DESCRIPTION
During inference on synapse detection, we will be loading the pre-trained model. The sample_label_size is not initialized globally leading to attribute errors. 