### PR TITLE
Load 3-channel label images in TIFF

### DIFF
--- a/connectomics/data/utils/data_io.py
+++ b/connectomics/data/utils/data_io.py
@@ -36,10 +36,15 @@ def savevol(filename, vol, dataset='main', format='h5'):
 
 def readim(filename, do_channel=False):
     # x,y,c
+    img_suf = filename[filename.rfind('.')+1:]
     if not os.path.exists(filename): 
         im = None
     else:# note: cv2 do "bgr" channel order
-        im = imageio.imread(filename)
+        if img_suf == 'tif':
+            im = cv2.imread(filename)
+            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+        else:
+            im = imageio.imread(filename)
         if do_channel and im.ndim==2:
             im=im[:,:,None]
     return im

--- a/connectomics/data/utils/data_io.py
+++ b/connectomics/data/utils/data_io.py
@@ -4,6 +4,7 @@ import glob
 import numpy as np
 import imageio
 from scipy.ndimage import zoom
+import cv2
 
 def readh5(filename, dataset=''):
     fid = h5py.File(filename,'r')


### PR DESCRIPTION
labels in tiff format with 3 channels will be loaded using cv2.imread separately. If load tiff using imageio.imread, only single channel image will be loaded in.