### PR TITLE
Fixes #98 - Enable the use of `dataset_volume.py` for unsupervised cases (label/mask = None) 

### DIFF
--- a/connectomics/data/dataset/dataset_volume.py
+++ b/connectomics/data/dataset/dataset_volume.py
@@ -179,11 +179,14 @@ class VolumeDataset(torch.utils.data.Dataset):
         out_volume = normalize_image(out_volume, self.data_mean, self.data_std)
 
         # output list
-        out_target = seg_to_targets(
-            out_label, self.target_opt, self.erosion_rates, self.dilation_rates)
-        out_weight = seg_to_weights(
-            out_target, self.weight_opt, out_valid, out_label)
-        return pos, out_volume, out_target, out_weight
+        if out_label is None:
+            return pos, out_volume, None, None
+        else:
+            out_target = self._seg_to_targets(
+                out_label, self.target_opt, self.erosion_rates, self.dilation_rates)
+            out_weight = self._seg_to_weights(
+                out_target, self.weight_opt, out_valid, out_label)
+            return pos, out_volume, out_target, out_weight
 
     #######################################################
     # Position Calculator
@@ -271,19 +274,21 @@ class VolumeDataset(torch.utils.data.Dataset):
         out_volume = (crop_volume(
             self.volume[pos[0]], vol_size, pos[1:])/255.0).astype(np.float32)
         # position in the label and valid mask
-        pos_l = np.round(pos[1:]*self.label_vol_ratio)
-        out_label = crop_volume(
-            self.label[pos[0]], self.sample_label_size, pos_l)
-        # For warping: cv2.remap requires input to be float32.
-        # Make labels index smaller. Otherwise uint32 and float32 are not
-        # the same for some values.
-        out_label = relabel(out_label.copy()).astype(np.float32)
-
+        out_label = None
         out_valid = None
-        if self.valid_mask is not None:
-            out_valid = crop_volume(self.label[pos[0]],
-                                    self.sample_label_size, pos_l)
-            out_valid = (out_valid != 0).astype(np.float32)
+        if self.label is not None:
+            pos_l = np.round(pos[1:]*self.label_vol_ratio)
+            out_label = self._crop_volume(
+                self.label[pos[0]], self.sample_label_size, pos_l)
+            # For warping: cv2.remap requires input to be float32.
+            # Make labels index smaller. Otherwise uint32 and float32 are not
+            # the same for some values.
+            out_label = self._relabel(out_label.copy()).astype(np.float32)
+
+            if self.valid_mask is not None:
+                out_valid = self._crop_volume(self.label[pos[0]],
+                                        self.sample_label_size, pos_l)
+                out_valid = (out_valid != 0).astype(np.float32)
 
         return pos, out_volume, out_label, out_valid
 
@@ -291,7 +296,7 @@ class VolumeDataset(torch.utils.data.Dataset):
         """Decide whether the sampled region is valid or not using
         the corresponding valid mask.
         """
-        if self.valid_mask is None:
+        if self.valid_mask is None or out_valid is None:
             return True
         ratio = float(out_valid.sum()) / np.prod(np.array(out_valid.shape))
         return ratio > self.valid_ratio


### PR DESCRIPTION
I added multiple switches to `dataset_volume.py`  that ensure its functionality in the case that labels and/or valid_mask is set to None. 

I tested my adaptation with dummy data for the following cases:
* `mode='train', volume=data, lable=data,  valid_mask=data`
* `mode='train', volume=data, lable=None,  valid_mask=data`
* `mode='train', volume=data, lable=data,  valid_mask=None`
* `mode='train', volume=data, lable=None,  valid_mask=None`

* `mode='test', volume=data, lable=data,  valid_mask=data`
* `mode='test', volume=data, lable=None,  valid_mask=data`
* `mode='test', volume=data, lable=data,  valid_mask=None`
* `mode='test', volume=data, lable=None,  valid_mask=None`

*  `mode='val', volume=data, lable=data,  valid_mask=data`
* `mode='val', volume=data, lable=None,  valid_mask=data`
* `mode='val', volume=data, lable=data,  valid_mask=None`
* `mode='val', volume=data, lable=None,  valid_mask=None`