### PR TITLE
added distributed backend config option

### DIFF
--- a/connectomics/config/defaults.py
+++ b/connectomics/config/defaults.py
@@ -15,6 +15,7 @@ _C.SYSTEM.NUM_CPUS = 4
 # Run distributed training using DistributedDataparallel model
 _C.SYSTEM.DISTRIBUTED = False
 _C.SYSTEM.PARALLEL = 'DP'
+_C.SYSTEM.DISTRIBUTED_BACKEND = 'nccl'
 # Debug mode is for tackle cases where this is no errors 
 # but the model behavior are unexpected.
 _C.SYSTEM.DEBUG = False

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -70,7 +70,7 @@ def main():
         device = torch.device("cuda", args.local_rank)
         assert torch.cuda.is_available(), \
             "Distributed training without GPUs is not supported!"
-        dist.init_process_group("nccl", init_method='env://')
+        dist.init_process_group(cfg.SYSTEM.DISTRIBUTED_BACKEND, init_method='env://')
     else:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 


### PR DESCRIPTION
Since windows cannot use nccl I added the option to the config to set the backend in a configfile. Default remains nccl