### PR TITLE
bump Cython version in requirements so _PyGen_Send error is not triggered in Python 3.10

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -100,7 +100,7 @@ dependencies:
       - connectomics==0.0.1.dev4
       - contourpy==1.1.1
       - cycler==0.12.1
-      - cython==0.29.21
+      - cython==0.29.22
       - debugpy==1.8.1
       - decorator==5.1.1
       - defusedxml==0.7.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
     'scikit-image>=0.17.2',
     'opencv-python>=4.3.0',
     'matplotlib>=3.3.0',
-    'Cython==0.29.21',
+    'Cython>=0.29.22',
     'yacs>=0.1.8',
     'h5py>=2.10.0',
     'gputil>=1.4.0',


### PR DESCRIPTION
Cython is used by waterz in the neuron segmentation tutorial
see https://github.com/Toblerity/Fiona/issues/1043#issuecomment-974886050