### PR TITLE
feat: Add 2D data processing support with do_2d flag

### DIFF
--- a/connectomics/config/hydra_config.py
+++ b/connectomics/config/hydra_config.py
@@ -329,10 +329,14 @@ class DataConfig:
     - Multi-channel label transformations
     - Train/validation splitting options
     - Caching and performance optimization
+    - 2D data support with do_2d parameter
     """
 
     # Dataset type
     dataset_type: Optional[str] = None  # Type of dataset: None (volume), 'filename', 'tile', etc.
+    
+    # 2D data support
+    do_2d: bool = False  # Enable 2D data processing (extract 2D slices from 3D volumes)
 
     # Paths - Volume-based datasets
     train_image: Optional[str] = None
@@ -755,6 +759,9 @@ class InferenceDataConfig:
         default_factory=list
     )  # Axis permutation for test data (e.g., [2,1,0] for xyz->zyx)
     output_path: str = "results/"
+    
+    # 2D data support
+    do_2d: bool = False  # Enable 2D data processing for inference
 
 
 @dataclass

--- a/connectomics/data/dataset/dataset_base.py
+++ b/connectomics/data/dataset/dataset_base.py
@@ -70,7 +70,11 @@ class MonaiConnectomicsDataset(Dataset):
         super().__init__(data=data_dicts, transform=transforms)
 
         # Store connectomics-specific parameters
-        self.sample_size = ensure_tuple_rep(sample_size, 3)
+        # For 2D data, use 2D dimensions; otherwise use 3D
+        if do_2d:
+            self.sample_size = ensure_tuple_rep(sample_size, 2)
+        else:
+            self.sample_size = ensure_tuple_rep(sample_size, 3)
         self.mode = mode
         self.iter_num = iter_num
         self.valid_ratio = valid_ratio

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -779,6 +779,7 @@ def create_datamodule(
             cache_rate=cfg.data.cache_rate if use_cache else 0.0,
             iter_num=iter_num_for_dataset,
             sample_size=tuple(cfg.data.patch_size),
+            do_2d=cfg.data.do_2d,
         )
         # Setup datasets based on mode
         if mode == "train":

--- a/tutorials/monai2d_worm.yaml
+++ b/tutorials/monai2d_worm.yaml
@@ -58,6 +58,9 @@ model:
 
 # Data - Using automatic 80/20 train/val split (DeepEM-style)
 data:
+  # 2D data support
+  do_2d: true                     # Enable 2D data processing (extract 2D slices from 3D volumes)
+  
   # Volume configuration
   train_image: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/imagesTr/*.tif
   train_label: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/labelsTr/*.tif
@@ -152,8 +155,9 @@ monitor:
 # Inference - MONAI SlidingWindowInferer
 inference:
   data:
-    test_image: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/imagesTr/Image96_00002_0000.tif
-    test_label: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/labelsTr/Image96_00002.tif
+    do_2d: true                     # Enable 2D data processing for inference
+    test_image: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/imagesTs/*.tif
+    test_label: /projects/weilab/shenb/PyTC/datasets/Dataset001_worm_image96/imagesTs/*.tif
     test_resolution: [5, 5]
     output_path: outputs/monai2d_worm/results/
 
@@ -188,7 +192,7 @@ inference:
   # Evaluation
   evaluation:
     enabled: true                        # Use eval mode for BatchNorm
-    metrics: [jaccard]             # Metrics to compute
+    metrics: [adapted_rand]        # Metrics to compute (adapted_rand for instance segmentation)
 
   # NOTE: batch_size=1 for inference
   #   During training: batch_size controls how many random patches to load


### PR DESCRIPTION
- Add do_2d parameter to DataConfig and InferenceDataConfig
- Modify MonaiConnectomicsDataset to handle 2D dimensions when do_2d=True
- Update model wrapper to squeeze/unsqueeze depth dimension for 2D models
- Disable sliding window inference for 2D models, use direct inference
- Make TTA flip axes dynamic based on data dimensions (2D vs 3D)
- Switch evaluation metric from Jaccard to Adapted Rand Error for instance segmentation
- Update monai2d_worm.yaml config to enable 2D processing

This enables seamless 2D data processing while maintaining 3D compatibility.