### PR TITLE
Add nnU-Net preprocessing pipeline and CLI switch

### DIFF
--- a/connectomics/config/hydra_config.py
+++ b/connectomics/config/hydra_config.py
@@ -350,6 +350,31 @@ class ImageTransformConfig:
 
 
 @dataclass
+class NNUNetPreprocessingConfig:
+    """nnU-Net-style preprocessing configuration.
+
+    This block controls preprocessing that should mirror nnU-Net's behavior:
+    - foreground crop
+    - spacing-aware resampling
+    - z-score or simple intensity normalization
+    - optional restoration to input space before saving predictions
+    """
+
+    enabled: bool = False
+    crop_to_nonzero: bool = True
+    target_spacing: Optional[List[float]] = None  # [z, y, x] for 3D, [y, x] for 2D
+    source_spacing: Optional[List[float]] = None  # If None, falls back to *_resolution fields
+    normalization: str = "zscore"  # "zscore", "none", "0-1", or "divide-K"
+    normalization_use_nonzero_mask: bool = True
+    force_separate_z: Optional[bool] = None  # None = auto
+    anisotropy_threshold: float = 3.0
+    image_order: int = 3
+    label_order: int = 0
+    order_z: int = 0
+    restore_to_input_space: bool = True
+
+
+@dataclass
 class DataConfig:
     """Dataset and data loading configuration.
 
@@ -438,6 +463,9 @@ class DataConfig:
 
     # Image transformation (applied to image only)
     image_transform: ImageTransformConfig = field(default_factory=ImageTransformConfig)
+    nnunet_preprocessing: NNUNetPreprocessingConfig = field(
+        default_factory=NNUNetPreprocessingConfig
+    )
 
     # Sampling (for volumetric datasets)
     iter_num_per_epoch: Optional[int] = None  # Alias for iter_num (if set, overrides iter_num)
@@ -888,6 +916,9 @@ class InferenceDataConfig:
 
     # Image transformation (applied to test images during inference)
     image_transform: ImageTransformConfig = field(default_factory=ImageTransformConfig)
+    nnunet_preprocessing: NNUNetPreprocessingConfig = field(
+        default_factory=NNUNetPreprocessingConfig
+    )
 
     # 2D data support
     do_2d: bool = False  # Enable 2D data processing for inference
@@ -1120,6 +1151,9 @@ class TestDataConfig:
     cache_suffix: str = "_prediction.h5"
     # Image transformation (applied to test images during inference)
     image_transform: ImageTransformConfig = field(default_factory=ImageTransformConfig)
+    nnunet_preprocessing: NNUNetPreprocessingConfig = field(
+        default_factory=NNUNetPreprocessingConfig
+    )
     # Label transformation (optional). Typically unused in test mode to preserve raw labels
     label_transform: Optional[LabelTransformConfig] = None
 
@@ -1145,6 +1179,9 @@ class TuneDataConfig:
     tune_resolution: Optional[List[int]] = None
     # Image transformation (applied to tune images during inference)
     image_transform: ImageTransformConfig = field(default_factory=ImageTransformConfig)
+    nnunet_preprocessing: NNUNetPreprocessingConfig = field(
+        default_factory=NNUNetPreprocessingConfig
+    )
     # Label transformation (optional). Typically unused in tune mode to preserve raw labels
     label_transform: Optional[LabelTransformConfig] = None
 

--- a/connectomics/data/io/__init__.py
+++ b/connectomics/data/io/__init__.py
@@ -52,6 +52,7 @@ from .utils import (
 # MONAI transforms
 from .monai_transforms import (
     LoadVolumed,
+    NNUNetPreprocessd,
     SaveVolumed,
     TileLoaderd,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "squeeze_arrays",
     # MONAI transforms
     "LoadVolumed",
+    "NNUNetPreprocessd",
     "SaveVolumed",
     "TileLoaderd",
 ]

--- a/connectomics/data/io/monai_transforms.py
+++ b/connectomics/data/io/monai_transforms.py
@@ -8,7 +8,7 @@ This module provides MONAI-compatible transforms for:
 """
 
 from __future__ import annotations
-from typing import Any, Dict, Tuple, Sequence
+from typing import Any, Dict, List, Optional, Tuple, Sequence, Union
 import numpy as np
 from monai.config import KeysCollection
 from monai.transforms import MapTransform
@@ -93,6 +93,412 @@ class LoadVolumed(MapTransform):
                 )
                 d[meta_key] = meta_dict
         return d
+
+
+class NNUNetPreprocessd(MapTransform):
+    """nnU-Net style preprocessing transform for inference/training parity.
+
+    This transform optionally applies:
+    - foreground crop
+    - spacing-aware resampling
+    - intensity normalization
+
+    It stores enough metadata in ``image_meta_dict['nnunet_preprocess']`` to
+    invert preprocessing before writing outputs.
+    """
+
+    def __init__(
+        self,
+        keys: KeysCollection,
+        image_key: str = "image",
+        enabled: bool = False,
+        crop_to_nonzero: bool = True,
+        source_spacing: Optional[Sequence[float]] = None,
+        target_spacing: Optional[Sequence[float]] = None,
+        normalization: str = "zscore",
+        normalization_use_nonzero_mask: bool = True,
+        force_separate_z: Optional[bool] = None,
+        anisotropy_threshold: float = 3.0,
+        image_order: int = 3,
+        label_order: int = 0,
+        order_z: int = 0,
+        allow_missing_keys: bool = False,
+    ):
+        super().__init__(keys, allow_missing_keys)
+        self.image_key = image_key
+        self.enabled = enabled
+        self.crop_to_nonzero = crop_to_nonzero
+        self.source_spacing = list(source_spacing) if source_spacing is not None else None
+        self.target_spacing = list(target_spacing) if target_spacing is not None else None
+        self.normalization = normalization
+        self.normalization_use_nonzero_mask = normalization_use_nonzero_mask
+        self.force_separate_z = force_separate_z
+        self.anisotropy_threshold = anisotropy_threshold
+        self.image_order = image_order
+        self.label_order = label_order
+        self.order_z = order_z
+
+    def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        d = dict(data)
+        if not self.enabled or self.image_key not in d:
+            return d
+
+        image_np, image_state = self._as_numpy(d[self.image_key])
+        spatial_dims = self._infer_spatial_dims(image_np)
+        image_spatial_shape = self._get_spatial_shape(image_np, spatial_dims)
+
+        meta_key = f"{self.image_key}_meta_dict"
+        meta_dict = dict(d.get(meta_key, {}))
+
+        source_spacing = self._normalize_spacing(
+            self.source_spacing or meta_dict.get("spacing") or meta_dict.get("resolution"),
+            spatial_dims,
+        )
+        target_spacing = self._normalize_spacing(self.target_spacing, spatial_dims)
+
+        preprocess_meta = {
+            "enabled": True,
+            "spatial_dims": spatial_dims,
+            "original_spatial_shape": list(image_spatial_shape),
+            "source_spacing": source_spacing,
+            "target_spacing": target_spacing,
+            "normalization": self.normalization,
+            "normalization_use_nonzero_mask": self.normalization_use_nonzero_mask,
+            "crop_bbox": None,
+            "cropped_spatial_shape": list(image_spatial_shape),
+            "resampled_spatial_shape": list(image_spatial_shape),
+            "applied_crop": False,
+            "applied_resample": False,
+            "transpose_axes": meta_dict.get("transpose_axes"),
+        }
+
+        bbox = None
+        if self.crop_to_nonzero:
+            nonzero_mask = self._create_nonzero_mask(image_np, spatial_dims)
+            if nonzero_mask is not None and np.any(nonzero_mask):
+                bbox = self._bbox_from_mask(nonzero_mask)
+                preprocess_meta["crop_bbox"] = [[int(b.start), int(b.stop)] for b in bbox]
+                preprocess_meta["applied_crop"] = True
+                for key in self.key_iterator(d):
+                    if key not in d:
+                        continue
+                    value_np, state = self._as_numpy(d[key])
+                    value_np = self._crop_to_bbox(value_np, bbox, spatial_dims)
+                    d[key] = self._from_numpy(value_np, state)
+                image_np = self._crop_to_bbox(image_np, bbox, spatial_dims)
+                preprocess_meta["cropped_spatial_shape"] = list(
+                    self._get_spatial_shape(image_np, spatial_dims)
+                )
+
+        target_shape = None
+        if source_spacing is not None and target_spacing is not None:
+            current_shape = np.array(preprocess_meta["cropped_spatial_shape"], dtype=np.float32)
+            spacing_factors = np.array(source_spacing, dtype=np.float32) / np.array(
+                target_spacing, dtype=np.float32
+            )
+            target_shape = np.maximum(np.round(current_shape * spacing_factors).astype(int), 1)
+            if np.any(target_shape != current_shape.astype(int)):
+                separate_z, lowres_axis = self._resolve_separate_z(
+                    source_spacing, target_spacing, spatial_dims
+                )
+                preprocess_meta["applied_resample"] = True
+                preprocess_meta["separate_z"] = separate_z
+                preprocess_meta["lowres_axis"] = lowres_axis
+                for key in self.key_iterator(d):
+                    if key not in d:
+                        continue
+                    value_np, state = self._as_numpy(d[key])
+                    is_seg = key != self.image_key
+                    value_np = self._resample_to_shape(
+                        value_np,
+                        target_shape=tuple(int(v) for v in target_shape),
+                        spatial_dims=spatial_dims,
+                        is_seg=is_seg,
+                        separate_z=separate_z,
+                        lowres_axis=lowres_axis,
+                    )
+                    d[key] = self._from_numpy(value_np, state)
+                image_np = self._resample_to_shape(
+                    image_np,
+                    target_shape=tuple(int(v) for v in target_shape),
+                    spatial_dims=spatial_dims,
+                    is_seg=False,
+                    separate_z=separate_z,
+                    lowres_axis=lowres_axis,
+                )
+                preprocess_meta["resampled_spatial_shape"] = list(
+                    self._get_spatial_shape(image_np, spatial_dims)
+                )
+
+        # Normalize image after spatial transforms.
+        image_np = self._normalize_image(
+            image_np,
+            spatial_dims=spatial_dims,
+            mode=self.normalization,
+            use_nonzero_mask=self.normalization_use_nonzero_mask,
+        )
+        d[self.image_key] = self._from_numpy(image_np, image_state)
+
+        meta_dict["nnunet_preprocess"] = preprocess_meta
+        d[meta_key] = meta_dict
+        return d
+
+    @staticmethod
+    def _infer_spatial_dims(array: np.ndarray) -> int:
+        if array.ndim <= 2:
+            return array.ndim
+        # Treat channel-first arrays as (C, spatial...).
+        return array.ndim - 1
+
+    @staticmethod
+    def _get_spatial_shape(array: np.ndarray, spatial_dims: int) -> tuple:
+        if array.ndim == spatial_dims:
+            return tuple(int(v) for v in array.shape)
+        return tuple(int(v) for v in array.shape[-spatial_dims:])
+
+    @staticmethod
+    def _as_numpy(value: Any) -> tuple[np.ndarray, Dict[str, Any]]:
+        if isinstance(value, np.ndarray):
+            return value, {"type": "numpy"}
+        try:
+            import torch
+
+            if isinstance(value, torch.Tensor):
+                return value.detach().cpu().numpy(), {
+                    "type": "torch",
+                    "device": value.device,
+                    "dtype": value.dtype,
+                }
+        except Exception:
+            pass
+        raise TypeError(f"NNUNetPreprocessd expects numpy arrays or tensors, got {type(value)}")
+
+    @staticmethod
+    def _from_numpy(value: np.ndarray, state: Dict[str, Any]) -> Any:
+        if state["type"] == "numpy":
+            return value
+        import torch
+
+        out = torch.from_numpy(value)
+        if "dtype" in state:
+            out = out.to(dtype=state["dtype"])
+        if "device" in state:
+            out = out.to(device=state["device"])
+        return out
+
+    @staticmethod
+    def _normalize_spacing(
+        spacing: Optional[Sequence[float]], spatial_dims: int
+    ) -> Optional[List[float]]:
+        if spacing is None:
+            return None
+        values = [float(v) for v in spacing]
+        if len(values) == spatial_dims:
+            return values
+        if len(values) > spatial_dims:
+            return values[-spatial_dims:]
+        return None
+
+    @staticmethod
+    def _create_nonzero_mask(image: np.ndarray, spatial_dims: int) -> Optional[np.ndarray]:
+        if image.ndim == spatial_dims + 1:
+            mask = np.any(image != 0, axis=0)
+        elif image.ndim == spatial_dims:
+            mask = image != 0
+        else:
+            return None
+        if not np.any(mask):
+            return None
+        from scipy.ndimage import binary_fill_holes
+
+        return binary_fill_holes(mask)
+
+    @staticmethod
+    def _bbox_from_mask(mask: np.ndarray) -> tuple[slice, ...]:
+        coords = np.where(mask)
+        return tuple(slice(int(np.min(c)), int(np.max(c)) + 1) for c in coords)
+
+    @staticmethod
+    def _crop_to_bbox(array: np.ndarray, bbox: tuple[slice, ...], spatial_dims: int) -> np.ndarray:
+        if array.ndim == spatial_dims + 1:
+            return array[(slice(None), *bbox)]
+        if array.ndim == spatial_dims:
+            return array[bbox]
+        return array
+
+    def _resolve_separate_z(
+        self, source_spacing: Sequence[float], target_spacing: Sequence[float], spatial_dims: int
+    ) -> tuple[bool, Optional[int]]:
+        if spatial_dims != 3:
+            return False, None
+        if self.force_separate_z is not None:
+            if not self.force_separate_z:
+                return False, None
+            axis = int(np.argmax(np.asarray(source_spacing)))
+            return True, axis
+        spacing = np.asarray(source_spacing, dtype=np.float32)
+        ratio = float(np.max(spacing) / np.maximum(np.min(spacing), 1e-8))
+        if ratio <= self.anisotropy_threshold:
+            spacing = np.asarray(target_spacing, dtype=np.float32)
+            ratio = float(np.max(spacing) / np.maximum(np.min(spacing), 1e-8))
+        if ratio <= self.anisotropy_threshold:
+            return False, None
+        axis = int(np.argmax(np.asarray(source_spacing)))
+        return True, axis
+
+    def _resample_to_shape(
+        self,
+        array: np.ndarray,
+        target_shape: tuple[int, ...],
+        spatial_dims: int,
+        is_seg: bool,
+        separate_z: bool,
+        lowres_axis: Optional[int],
+    ) -> np.ndarray:
+        if self._get_spatial_shape(array, spatial_dims) == target_shape:
+            return array
+        order = self.label_order if is_seg else self.image_order
+
+        if array.ndim == spatial_dims + 1:
+            channels = [
+                self._resample_spatial(
+                    array[c],
+                    target_shape=target_shape,
+                    order=order,
+                    is_seg=is_seg,
+                    separate_z=separate_z,
+                    lowres_axis=lowres_axis,
+                )[None]
+                for c in range(array.shape[0])
+            ]
+            return np.vstack(channels).astype(array.dtype, copy=False)
+
+        if array.ndim == spatial_dims:
+            return self._resample_spatial(
+                array,
+                target_shape=target_shape,
+                order=order,
+                is_seg=is_seg,
+                separate_z=separate_z,
+                lowres_axis=lowres_axis,
+            ).astype(array.dtype, copy=False)
+
+        return array
+
+    def _resample_spatial(
+        self,
+        array: np.ndarray,
+        target_shape: tuple[int, ...],
+        order: int,
+        is_seg: bool,
+        separate_z: bool,
+        lowres_axis: Optional[int],
+    ) -> np.ndarray:
+        from scipy.ndimage import zoom
+
+        current_shape = np.array(array.shape, dtype=np.float32)
+        target = np.array(target_shape, dtype=np.float32)
+        if np.all(current_shape == target):
+            return array
+
+        if not separate_z or lowres_axis is None:
+            factors = target / current_shape
+            return zoom(
+                array.astype(np.float32, copy=False),
+                zoom=factors,
+                order=order,
+                mode="nearest",
+                prefilter=order > 1,
+            )
+
+        # nnU-Net style anisotropic resample: in-plane first, then low-res axis.
+        axis = int(lowres_axis)
+        inplane_axes = [i for i in range(3) if i != axis]
+        slices: List[np.ndarray] = []
+        for i in range(array.shape[axis]):
+            if axis == 0:
+                part = array[i, :, :]
+            elif axis == 1:
+                part = array[:, i, :]
+            else:
+                part = array[:, :, i]
+
+            plane_factors = [
+                target[inplane_axes[0]] / max(part.shape[0], 1),
+                target[inplane_axes[1]] / max(part.shape[1], 1),
+            ]
+            resized = zoom(
+                part.astype(np.float32, copy=False),
+                zoom=plane_factors,
+                order=order,
+                mode="nearest",
+                prefilter=order > 1,
+            )
+            slices.append(resized)
+
+        stacked = np.stack(slices, axis=axis)
+        if stacked.shape[axis] != int(target[axis]):
+            axis_factors = np.ones(3, dtype=np.float32)
+            axis_factors[axis] = target[axis] / max(stacked.shape[axis], 1)
+            stacked = zoom(
+                stacked.astype(np.float32, copy=False),
+                zoom=axis_factors,
+                order=self.order_z if not is_seg else self.label_order,
+                mode="nearest",
+                prefilter=(self.order_z > 1) and (not is_seg),
+            )
+        return stacked
+
+    @staticmethod
+    def _normalize_image(
+        image: np.ndarray,
+        spatial_dims: int,
+        mode: str,
+        use_nonzero_mask: bool,
+    ) -> np.ndarray:
+        if mode in (None, "none"):
+            return image
+
+        image = image.astype(np.float32, copy=False)
+
+        def _apply(volume: np.ndarray, mask: Optional[np.ndarray]) -> np.ndarray:
+            mode_lower = str(mode).lower().strip()
+            if mask is not None and np.any(mask):
+                values = volume[mask]
+            else:
+                values = volume.reshape(-1)
+            if values.size == 0:
+                return volume
+
+            if mode_lower in ("zscore", "normal"):
+                mean = float(values.mean())
+                std = float(values.std())
+                if std > 1e-8:
+                    volume = (volume - mean) / std
+            elif mode_lower == "0-1":
+                low = float(values.min())
+                high = float(values.max())
+                if high > low:
+                    volume = (volume - low) / (high - low)
+            elif mode_lower.startswith("divide-"):
+                scale = float(mode_lower.split("-", 1)[1])
+                if abs(scale) > 1e-8:
+                    volume = volume / scale
+            return volume
+
+        if image.ndim == spatial_dims + 1:
+            nonzero_mask = np.any(image != 0, axis=0) if use_nonzero_mask else None
+            for c in range(image.shape[0]):
+                image[c] = _apply(image[c], nonzero_mask)
+                if nonzero_mask is not None:
+                    image[c][~nonzero_mask] = 0
+            return image
+
+        mask = image != 0 if use_nonzero_mask else None
+        image = _apply(image, mask)
+        if mask is not None:
+            image[~mask] = 0
+        return image
 
 
 class SaveVolumed(MapTransform):
@@ -209,6 +615,7 @@ class TileLoaderd(MapTransform):
 
 __all__ = [
     "LoadVolumed",
+    "NNUNetPreprocessd",
     "SaveVolumed",
     "TileLoaderd",
 ]

--- a/connectomics/training/lit/model.py
+++ b/connectomics/training/lit/model.py
@@ -815,7 +815,14 @@ class ConnectomicsModule(pl.LightningModule):
             print(f"  💾 [STAGE: Saving Final Predictions]")
             save_start = time.time()
             
-            write_outputs(self.cfg, postprocessed_predictions, filenames, suffix="prediction", mode=mode)
+            write_outputs(
+                self.cfg,
+                postprocessed_predictions,
+                filenames,
+                suffix="prediction",
+                mode=mode,
+                batch_meta=batch.get("image_meta_dict"),
+            )
             
             save_duration = time.time() - save_start
             print(f"  ✅ Final predictions saved ({save_duration:.1f}s)")
@@ -911,7 +918,14 @@ class ConnectomicsModule(pl.LightningModule):
             
             # Apply intensity scaling and dtype conversion before saving
             predictions_to_save = apply_save_prediction_transform(self.cfg, predictions_np)
-            write_outputs(self.cfg, predictions_to_save, filenames, suffix="tta_prediction", mode=mode)
+            write_outputs(
+                self.cfg,
+                predictions_to_save,
+                filenames,
+                suffix="tta_prediction",
+                mode=mode,
+                batch_meta=batch.get("image_meta_dict"),
+            )
             
             save_duration = time.time() - save_start
             print(f"  ✅ Intermediate predictions saved ({save_duration:.1f}s)")
@@ -945,7 +959,14 @@ class ConnectomicsModule(pl.LightningModule):
         print(f"  💾 [STAGE: Saving Final Predictions]")
         final_save_start = time.time()
         
-        write_outputs(self.cfg, postprocessed_predictions, filenames, suffix="prediction", mode=mode)
+        write_outputs(
+            self.cfg,
+            postprocessed_predictions,
+            filenames,
+            suffix="prediction",
+            mode=mode,
+            batch_meta=batch.get("image_meta_dict"),
+        )
         
         final_save_duration = time.time() - final_save_start
         print(f"  ✅ Final predictions saved ({final_save_duration:.1f}s)")

--- a/connectomics/training/lit/utils.py
+++ b/connectomics/training/lit/utils.py
@@ -98,6 +98,14 @@ def parse_args():
         help="Run N batches for quick debugging (default: 0, no argument defaults to 1)",
     )
     parser.add_argument(
+        "--nnunet-preprocess",
+        action="store_true",
+        help=(
+            "Enable nnU-Net-style preprocessing (foreground crop, spacing-aware "
+            "resampling, normalization) for this run"
+        ),
+    )
+    parser.add_argument(
         "--external-prefix",
         type=str,
         default=None,
@@ -249,6 +257,18 @@ def setup_config(args) -> Config:
         if cfg.inference.num_workers >= 0:
             print(f"🔧 Inference override: num_workers={cfg.inference.num_workers}")
             cfg.system.inference.num_workers = cfg.inference.num_workers
+
+    # Optional convenience toggle to enable nnU-Net preprocessing via CLI
+    if getattr(args, "nnunet_preprocess", False):
+        print("🔧 Enabling nnU-Net preprocessing from CLI flag")
+        if hasattr(cfg, "data") and hasattr(cfg.data, "nnunet_preprocessing"):
+            cfg.data.nnunet_preprocessing.enabled = True
+        if hasattr(cfg, "test") and cfg.test and hasattr(cfg.test, "data"):
+            if hasattr(cfg.test.data, "nnunet_preprocessing"):
+                cfg.test.data.nnunet_preprocessing.enabled = True
+        if hasattr(cfg, "tune") and cfg.tune and hasattr(cfg.tune, "data"):
+            if hasattr(cfg.tune.data, "nnunet_preprocessing"):
+                cfg.tune.data.nnunet_preprocessing.enabled = True
 
     # Auto-planning (if enabled)
     if hasattr(cfg.system, "auto_plan") and cfg.system.auto_plan:

--- a/tests/unit/test_lit_utils.py
+++ b/tests/unit/test_lit_utils.py
@@ -14,7 +14,13 @@ from connectomics.training.lit.utils import (
 )
 
 
-def _make_args(config_path: Path, overrides=None, fast_dev_run: int = 0, mode: str = "train"):
+def _make_args(
+    config_path: Path,
+    overrides=None,
+    fast_dev_run: int = 0,
+    mode: str = "train",
+    nnunet_preprocess: bool = False,
+):
     return argparse.Namespace(
         config=str(config_path),
         demo=False,
@@ -29,6 +35,7 @@ def _make_args(config_path: Path, overrides=None, fast_dev_run: int = 0, mode: s
         params=None,
         param_source=None,
         tune_trials=None,
+        nnunet_preprocess=nnunet_preprocess,
         overrides=overrides or [],
     )
 
@@ -54,6 +61,19 @@ def test_setup_config_applies_overrides_and_fast_dev_run(tmp_path):
     assert updated.optimization.max_epochs == 5
     assert updated.system.training.batch_size == 2
     assert updated.system.training.num_workers == 0  # forced by fast-dev-run
+
+
+def test_setup_config_enables_nnunet_preprocess_from_cli_switch(tmp_path):
+    cfg = Config()
+    assert cfg.data.nnunet_preprocessing.enabled is False
+
+    cfg_path = tmp_path / "config.yaml"
+    save_config(cfg, cfg_path)
+
+    args = _make_args(cfg_path, nnunet_preprocess=True)
+    updated = setup_config(args)
+
+    assert updated.data.nnunet_preprocessing.enabled is True
 
 
 def test_expand_file_paths_handles_globs_and_lists(tmp_path):

--- a/tests/unit/test_main_cli_contract.py
+++ b/tests/unit/test_main_cli_contract.py
@@ -32,6 +32,14 @@ def test_parse_args_fast_dev_run_default_and_explicit(monkeypatch):
     assert args.fast_dev_run == 3
 
 
+def test_parse_args_nnunet_preprocess_switch(monkeypatch):
+    args = _parse_with_argv(monkeypatch, [])
+    assert args.nnunet_preprocess is False
+
+    args = _parse_with_argv(monkeypatch, ["--nnunet-preprocess"])
+    assert args.nnunet_preprocess is True
+
+
 def test_parse_args_preserves_overrides_passthrough(monkeypatch):
     args = _parse_with_argv(
         monkeypatch,

--- a/tests/unit/test_nnunet_preprocessing.py
+++ b/tests/unit/test_nnunet_preprocessing.py
@@ -1,0 +1,100 @@
+"""Tests for nnU-Net style preprocessing and output restoration."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from connectomics.config import Config
+from connectomics.data.io import NNUNetPreprocessd, read_hdf5
+from connectomics.inference.io import _restore_prediction_to_input_space, write_outputs
+
+
+def test_nnunet_preprocess_crops_and_tracks_metadata():
+    image = np.zeros((1, 6, 8, 10), dtype=np.float32)
+    image[:, 2:5, 3:7, 4:9] = 10.0
+    data = {
+        "image": image,
+        "image_meta_dict": {"filename_or_obj": "toy_volume.h5", "transpose_axes": None},
+    }
+
+    transform = NNUNetPreprocessd(
+        keys=["image"],
+        enabled=True,
+        crop_to_nonzero=True,
+        normalization="zscore",
+        normalization_use_nonzero_mask=True,
+    )
+    result = transform(data)
+
+    out = result["image"]
+    assert out.shape == (1, 3, 4, 5)
+
+    meta = result["image_meta_dict"]["nnunet_preprocess"]
+    assert meta["applied_crop"] is True
+    assert meta["crop_bbox"] == [[2, 5], [3, 7], [4, 9]]
+    assert meta["original_spatial_shape"] == [6, 8, 10]
+    assert meta["cropped_spatial_shape"] == [3, 4, 5]
+
+
+def test_restore_prediction_inverts_resampling():
+    image = np.random.RandomState(0).rand(1, 4, 6, 8).astype(np.float32)
+    data = {
+        "image": image,
+        "image_meta_dict": {"filename_or_obj": "toy_volume.h5", "transpose_axes": None},
+    }
+
+    transform = NNUNetPreprocessd(
+        keys=["image"],
+        enabled=True,
+        crop_to_nonzero=False,
+        source_spacing=[2.0, 1.0, 1.0],
+        target_spacing=[1.0, 1.0, 1.0],
+        normalization="none",
+    )
+    result = transform(data)
+    pre_shape = result["image"].shape[1:]
+    assert pre_shape == (8, 6, 8)
+
+    pred = np.random.RandomState(1).rand(2, *pre_shape).astype(np.float32)
+    restored = _restore_prediction_to_input_space(pred, result["image_meta_dict"])
+    assert restored.shape == (2, 4, 6, 8)
+
+
+def test_write_outputs_restores_to_input_space(tmp_path):
+    image = np.zeros((1, 5, 7, 9), dtype=np.float32)
+    image[:, 1:4, 2:6, 3:8] = 1.0
+    data = {
+        "image": image,
+        "image_meta_dict": {"filename_or_obj": "toy_volume.h5", "transpose_axes": None},
+    }
+
+    transform = NNUNetPreprocessd(
+        keys=["image"],
+        enabled=True,
+        crop_to_nonzero=True,
+        normalization="none",
+    )
+    result = transform(data)
+
+    pre_shape = result["image"].shape[1:]
+    predictions = np.ones((1, 1, *pre_shape), dtype=np.float32)
+
+    from connectomics.config.hydra_config import TestConfig as HydraTestConfig
+
+    cfg = Config()
+    cfg.test = HydraTestConfig()
+    cfg.test.data.output_path = str(tmp_path)
+    cfg.test.data.nnunet_preprocessing.enabled = True
+    cfg.test.data.nnunet_preprocessing.restore_to_input_space = True
+
+    write_outputs(
+        cfg=cfg,
+        predictions=predictions,
+        filenames=["toy_volume"],
+        suffix="prediction",
+        mode="test",
+        batch_meta=[result["image_meta_dict"]],
+    )
+
+    saved = read_hdf5(str(tmp_path / "toy_volume_prediction.h5"), dataset="main")
+    assert saved.shape == (5, 7, 9)

--- a/tutorials/misc/mito_2dsem_seg.yaml
+++ b/tutorials/misc/mito_2dsem_seg.yaml
@@ -210,6 +210,16 @@ test:
   data:
     test_image: datasets/mito2d/test_images.h5
     test_label: datasets/mito2d/test_labels.h5
+    # Physical voxel spacing [z, y, x] (required for spacing-aware resampling)
+    test_resolution: [30.0, 8.0, 8.0]
+    nnunet_preprocessing:
+      enabled: true
+      crop_to_nonzero: true
+      # Keep null to skip spacing resampling; set explicit spacing to match model plans.
+      target_spacing: null
+      normalization: zscore
+      normalization_use_nonzero_mask: true
+      restore_to_input_space: true
 
   evaluation:
     enabled: true


### PR DESCRIPTION
## Summary
- add typed nnU-Net preprocessing config (`nnunet_preprocessing`) across training/test/tune data configs
- introduce `NNUNetPreprocessd` transform to perform foreground cropping, spacing-aware resampling, and nnU-Net-style normalization with reversible metadata
- integrate preprocessing into train/val/test/tune transform builders and avoid duplicate intensity normalization when enabled
- restore decoded predictions back to input space before writing outputs when configured
- add CLI switch `--nnunet-preprocess` to enable preprocessing quickly for a run
- add tutorial config example and unit tests for preprocessing + CLI behavior

## Validation
- `pytest -q tests/unit/test_main_cli_contract.py`
- `pytest -q tests/unit/test_lit_utils.py`
- `pytest -q tests/unit/test_nnunet_preprocessing.py`
