### PR TITLE
Fiber segmentation fixes

### DIFF
--- a/connectomics/config/hydra_config.py
+++ b/connectomics/config/hydra_config.py
@@ -520,6 +520,10 @@ class SchedulerConfig:
     # CosineAnnealing-specific
     t_max: Optional[int] = None
 
+    # CosineAnnealingWarmRestarts-specific
+    T_0: int = 200
+    T_mult: int = 1
+
     # ReduceLROnPlateau-specific
     mode: str = "min"  # 'min' or 'max'
     patience: int = 10
@@ -1195,7 +1199,7 @@ class TuneDataConfig:
 class TuneOutputConfig:
     """Tuning output configuration."""
 
-    output_dir: str = "outputs/tuning"
+    output_dir: Optional[str] = None
     output_pred: Optional[str] = None
     cache_suffix: str = "_tta_prediction.h5"
     save_all_trials: bool = False

--- a/connectomics/data/dataset/dataset_volume_cached.py
+++ b/connectomics/data/dataset/dataset_volume_cached.py
@@ -491,7 +491,7 @@ class CachedVolumeDataset(Dataset):
         # [D2] Foreground-aware patch sampling: ensure patches contain sufficient mitochondria
         # This prevents SDT collapse by avoiding background-only patches
         max_attempts = 10
-        foreground_threshold = 0.05  # Require at least 5% foreground (SDT > 0)
+        foreground_threshold = 0.01  # Require at least 1% foreground (fibers are sparse ~2% density)
         
         # [D2 DIAGNOSTIC] Track sampling attempts
         attempts_used = 0
@@ -550,7 +550,7 @@ class CachedVolumeDataset(Dataset):
             print(f"  Avg attempts per patch: {avg_attempts:.2f}/{max_attempts}")
             print(f"  Patches rejected: {self._d2_rejected_patches}/{self._d2_total_attempts} ({reject_rate:.1f}%)")
             print(f"  Final foreground %: avg={avg_fg:.1f}%, min={min_fg:.1f}%, max={max_fg:.1f}%")
-            print(f"  Threshold: {foreground_threshold*100:.1f}% (5% minimum)")
+            print(f"  Threshold: {foreground_threshold*100:.1f}% (1% minimum)")
 
         # Create data dict
         data = {

--- a/connectomics/inference/io.py
+++ b/connectomics/inference/io.py
@@ -252,10 +252,10 @@ def apply_postprocessing(cfg: Config | DictConfig, data: np.ndarray) -> np.ndarr
 def apply_decode_mode(cfg: Config | DictConfig, data: np.ndarray) -> np.ndarray:
     """Apply decode mode transformations to convert probability maps to instance segmentation."""
     decode_modes = None
-    if hasattr(cfg, "test") and cfg.test and hasattr(cfg.test, "decoding"):
+    if hasattr(cfg, "test") and cfg.test and hasattr(cfg.test, "decoding") and cfg.test.decoding:
         decode_modes = cfg.test.decoding
         print(f"  🔧 Using test.decoding: {decode_modes}")
-    elif hasattr(cfg, "inference") and hasattr(cfg.inference, "decoding"):
+    elif hasattr(cfg, "inference") and hasattr(cfg.inference, "decoding") and cfg.inference.decoding:
         decode_modes = cfg.inference.decoding
         print(f"  🔧 Using inference.decoding: {decode_modes}")
 

--- a/connectomics/models/solver/build.py
+++ b/connectomics/models/solver/build.py
@@ -7,7 +7,7 @@ Code adapted from Detectron2 (https://github.com/facebookresearch/detectron2)
 
 from typing import Any, Dict, List, Set
 import torch
-from torch.optim.lr_scheduler import MultiStepLR, ReduceLROnPlateau, CosineAnnealingLR, StepLR
+from torch.optim.lr_scheduler import MultiStepLR, ReduceLROnPlateau, CosineAnnealingLR, CosineAnnealingWarmRestarts, StepLR
 
 from .lr_scheduler import WarmupCosineLR
 
@@ -167,6 +167,18 @@ def _build_lr_scheduler_hydra(
         scheduler = CosineAnnealingLR(
             optimizer,
             T_max=t_max,
+            eta_min=eta_min,
+        )
+
+    elif scheduler_name in ("cosineannealingwarmrestarts", "cosinewarmrestarts"):
+        T_0 = sched_cfg.T_0 if hasattr(sched_cfg, "T_0") else 200
+        T_mult = sched_cfg.T_mult if hasattr(sched_cfg, "T_mult") else 1
+        eta_min = sched_cfg.min_lr if hasattr(sched_cfg, "min_lr") else 1e-5
+
+        scheduler = CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=T_0,
+            T_mult=T_mult,
             eta_min=eta_min,
         )
 

--- a/connectomics/utils/debug_utils.py
+++ b/connectomics/utils/debug_utils.py
@@ -52,9 +52,9 @@ def print_tensor_stats(
         tensor = torch.from_numpy(tensor)
     
     # Convert to float for statistics computation if needed
-    # (uint8, int types don't support mean/std operations)
+    # (uint8, uint16, int types don't support mean/std operations)
     original_dtype = tensor.dtype
-    if tensor.dtype in [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]:
+    if tensor.dtype in [torch.uint8, torch.uint16, torch.int8, torch.int16, torch.int32, torch.int64]:
         tensor = tensor.float()
     
     # Mark as printed


### PR DESCRIPTION
Optuna tuner: Fixed per-volume evaluation (no more instance ID collisions), filtered out postprocessing params from decode kwargs, and added precision/recall logging.
Debug utils: Added torch.uint16 support to prevent dtype-related crashes.
Inference & Lightning model: Added null-checks for decoding/eval configs and robust handling of AdaptedRandError dict output.
Scheduler: Added CosineAnnealingWarmRestarts support (config + build).
Dataset: Lowered foreground_threshold from 5% to 1% for sparse fiber data, improving patch sampling.
Config: Made TuneOutputConfig.output_dir optional to fix OmegaConf validation errors.