### PR TITLE
Chunked/lazy sliding-window inference + zebrafinch OME-Zarr pipeline

### DIFF
--- a/connectomics/config/schema/inference.py
+++ b/connectomics/config/schema/inference.py
@@ -115,6 +115,8 @@ class ChunkingConfig:
     chunk_size: Optional[List[int]] = None  # ZYX after test-time val_transpose.
     halo: List[int] = field(default_factory=lambda: [0, 0, 0])
     axes: str = "all"  # "all" or "z"; "z" keeps full YX in each chunk.
+    shard_id: Optional[int] = None  # External naive chunk shard index; set by CLI.
+    num_shards: Optional[int] = None  # External naive chunk shard count; set by CLI.
     temp_dir: str = ""
     save_intermediate: bool = False
     stitching: ChunkStitchingConfig = field(default_factory=ChunkStitchingConfig)
@@ -203,7 +205,9 @@ class InferenceConfig:
     # All `save_*` siblings group together under one prefix per the v3 naming rule.
     save_results: bool = False
     save_path: str = ""
-    save_cache_suffix: str = "_x1_prediction.h5"  # Includes extension; keep aligned with save_backend.
+    save_cache_suffix: str = (
+        "_x1_prediction.h5"  # Includes extension; keep aligned with save_backend.
+    )
     save_all_heads: bool = False
     save_dtype: Optional[str] = None
     save_backend: str = "h5"  # "h5", "zarr", or "tensorstore" when implemented by runtime.
@@ -298,4 +302,3 @@ def sync_inference_runtime_aliases(cfg: object) -> None:
                     "border_mask",
                 ],
             )
-

--- a/connectomics/data/io/tiles.py
+++ b/connectomics/data/io/tiles.py
@@ -26,6 +26,7 @@ def reconstruct_volume_from_tiles(
     tile_ratio: float = 1.0,
     is_image: bool = True,
     background_value: int = 128,
+    num_workers: int = 1,
 ) -> np.ndarray:
     """Construct a volume from image tiles.
 
@@ -39,6 +40,10 @@ def reconstruct_volume_from_tiles(
         tile_ratio: Scale factor for tiles. Default 1.0.
         is_image: If True, use linear interp for resize.
         background_value: Fill value. Default 128.
+        num_workers: Threads used to decode/assemble z-sections in parallel.
+            1 (default) keeps the serial path. Each section writes a disjoint
+            ``result[z]`` plane, so threads are safe and image decoding (which
+            releases the GIL) scales with cores.
     """
     if tile_start is None:
         tile_start = [0, 0]
@@ -72,7 +77,7 @@ def reconstruct_volume_from_tiles(
     row_start = y0 // tile_h
     row_end = (y1 + tile_h - 1) // tile_h
 
-    for z in range(z0, z1):
+    def _fill_plane(z: int) -> None:
         pattern = tile_paths[z]
         for row in range(row_start, row_end):
             for col in range(col_start, col_end):
@@ -126,6 +131,16 @@ def reconstruct_volume_from_tiles(
                             xa - xps : xe - xps,
                         ]
                     )
+
+    z_indices = range(z0, z1)
+    if num_workers and int(num_workers) > 1 and (z1 - z0) > 1:
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=min(int(num_workers), z1 - z0)) as pool:
+            list(pool.map(_fill_plane, z_indices))
+    else:
+        for z in z_indices:
+            _fill_plane(z)
 
     if max(boundary_diffs) > 0:
         result = np.pad(

--- a/connectomics/inference/__init__.py
+++ b/connectomics/inference/__init__.py
@@ -9,6 +9,7 @@ from .artifact import (
 )
 from .chunked import (
     is_chunked_inference_enabled,
+    is_external_chunk_sharding_enabled,
     run_chunked_prediction_inference,
 )
 from .manager import InferenceManager
@@ -18,14 +19,14 @@ from .output import (
     resolve_output_filenames,
     write_outputs,
 )
+from .stage import run_prediction_inference
+from .tta import TTAPredictor
 from .window import (
     build_sliding_inferer,
     is_2d_inference_mode,
     resolve_inferer_overlap,
     resolve_inferer_roi_size,
 )
-from .stage import run_prediction_inference
-from .tta import TTAPredictor
 
 __all__ = [
     "InferenceManager",
@@ -35,6 +36,7 @@ __all__ = [
     "write_prediction_artifact",
     "write_prediction_artifact_attrs",
     "run_prediction_inference",
+    "is_external_chunk_sharding_enabled",
     "is_chunked_inference_enabled",
     "run_chunked_prediction_inference",
     "apply_prediction_transform",

--- a/connectomics/inference/chunked.py
+++ b/connectomics/inference/chunked.py
@@ -7,14 +7,13 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import torch
 
+from ..chunked.chunk_grid import ChunkRef, build_chunk_grid
 from .artifact import (
     build_prediction_artifact_metadata,
     write_prediction_artifact,
 )
-from ..chunked.chunk_grid import ChunkRef, build_chunk_grid
 from .chunk_grid import (
     resolve_chunk_shape,
     resolve_global_prediction_crop,
@@ -55,6 +54,31 @@ def _chunk_file_path(chunks_dir: Path, chunk: ChunkRef) -> Path:
 def _distributed_barrier() -> None:
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         torch.distributed.barrier()
+
+
+def _resolve_external_chunk_shard(cfg: Any) -> tuple[int, int] | None:
+    chunking_cfg = getattr(getattr(cfg, "inference", None), "chunking", None)
+    if chunking_cfg is None:
+        return None
+    shard_id = getattr(chunking_cfg, "shard_id", None)
+    num_shards = getattr(chunking_cfg, "num_shards", None)
+    if shard_id is None and num_shards is None:
+        return None
+    if shard_id is None or num_shards is None:
+        raise ValueError("Both inference.chunking.shard_id and num_shards must be set together.")
+    shard_id = int(shard_id)
+    num_shards = int(num_shards)
+    if num_shards <= 0:
+        raise ValueError(f"inference.chunking.num_shards must be positive, got {num_shards}.")
+    if shard_id < 0 or shard_id >= num_shards:
+        raise ValueError(
+            f"inference.chunking.shard_id={shard_id} out of range for num_shards={num_shards}."
+        )
+    return shard_id, num_shards
+
+
+def is_external_chunk_sharding_enabled(cfg: Any) -> bool:
+    return _resolve_external_chunk_shard(cfg) is not None
 
 
 def _write_chunk_index(
@@ -177,9 +201,7 @@ def _stitch_chunk_prediction_files(
                         )
                     ] = slab
                     if qc_streaming_callback is not None:
-                        qc_streaming_callback.update(
-                            slab, z_offset=global_z0, z_axis=1
-                        )
+                        qc_streaming_callback.update(slab, z_offset=global_z0, z_axis=1)
 
     write_prediction_artifact(
         output_path,
@@ -240,6 +262,8 @@ def _run_chunked_prediction_per_rank(
     rank: int,
     world_size: int,
     qc_streaming_callback: Any = None,
+    stitch_output: bool = True,
+    use_distributed_barrier: bool = True,
 ) -> Path:
     """Per-rank chunked raw inference. Each rank writes its own per-chunk h5 files.
 
@@ -369,7 +393,8 @@ def _run_chunked_prediction_per_rank(
 
         del pred, core_pred
 
-    _distributed_barrier()
+    if use_distributed_barrier:
+        _distributed_barrier()
 
     if rank == 0:
         index_path = _write_chunk_index(
@@ -385,11 +410,14 @@ def _run_chunked_prediction_per_rank(
             world_size=world_size,
         )
         logger.info(
-            "Per-rank chunked raw prediction wrote %d chunks to %s; index=%s",
+            "Chunked raw prediction shard wrote chunk metadata for %d chunks to %s; index=%s",
             len(chunks),
             chunks_dir,
             index_path,
         )
+        if not stitch_output:
+            return chunks_dir
+
         logger.info("Stitching %d per-rank chunks into %s", len(chunks), output_path)
         _stitch_chunk_prediction_files(
             cfg=cfg,
@@ -450,6 +478,35 @@ def run_chunked_prediction_inference(
     compression = getattr(cfg.inference, "save_compression", "gzip")
     compression = None if compression in (None, "", "none") else compression
     h5_spatial_chunks = resolve_h5_spatial_chunks(final_shape)
+
+    external_shard = _resolve_external_chunk_shard(cfg)
+    if external_shard is not None:
+        shard_id, num_shards = external_shard
+        return _run_chunked_prediction_per_rank(
+            cfg=cfg,
+            forward_fn=forward_fn,
+            image_path=image_path,
+            output_path=output_path,
+            checkpoint_path=checkpoint_path,
+            mask_path=mask_path,
+            mask_align_to_image=mask_align_to_image,
+            requested_head=requested_head,
+            device=device,
+            chunks=chunks,
+            input_shape=input_shape,
+            final_shape=final_shape,
+            crop_pad=crop_pad,
+            crop_before=crop_before,
+            chunk_shape=chunk_shape,
+            halo=halo,
+            compression=compression,
+            h5_spatial_chunks=h5_spatial_chunks,
+            rank=shard_id,
+            world_size=num_shards,
+            qc_streaming_callback=None,
+            stitch_output=False,
+            use_distributed_barrier=False,
+        )
 
     rank, world_size = _resolve_distributed_rank()
     if world_size > 1:
@@ -544,9 +601,13 @@ def run_chunked_prediction_inference(
         z0 = int(chunk_obj.slices[0].start)
         qc_streaming_callback.update(arr, z_offset=z0, z_axis=1)
 
-    def write_chunks(dataset) -> None:
-        dataset[(slice(None), *first_chunk.slices)] = first_core_pred
-        _stream_qc(first_chunk, first_core_pred)
+    def write_chunks(
+        dataset,
+        initial_chunk=first_chunk,
+        initial_core_pred=first_core_pred,
+    ) -> None:
+        dataset[(slice(None), *initial_chunk.slices)] = initial_core_pred
+        _stream_qc(initial_chunk, initial_core_pred)
         for chunk, core_pred in prediction_iter:
             dataset[(slice(None), *chunk.slices)] = core_pred
             _stream_qc(chunk, core_pred)
@@ -589,6 +650,7 @@ def run_chunked_prediction_inference(
 
 __all__ = [
     "ChunkRef",
+    "is_external_chunk_sharding_enabled",
     "is_chunked_inference_enabled",
     "run_chunked_prediction_inference",
 ]

--- a/connectomics/inference/lazy.py
+++ b/connectomics/inference/lazy.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import itertools
+import json
 import math
+from pathlib import Path
 from typing import Callable, Optional, Sequence
 
 import numpy as np
 import torch
 import torch.nn.functional as F
-from .window import dense_patch_slices
+
 from .window import compute_scan_interval as _get_scan_interval  # in-house
+from .window import dense_patch_slices
 
 try:
     from tqdm.auto import tqdm
@@ -26,6 +29,7 @@ from .lazy_distributed import (
     is_distributed_window_sharding_enabled as _is_distributed_window_sharding_enabled,
 )
 from .lazy_distributed import validate_distributed_patch_shard as _validate_distributed_patch_shard
+from .tta import TTAPredictor
 from .window import (
     apply_border_mask,
     build_sliding_accumulator_weight_maps,
@@ -35,7 +39,123 @@ from .window import (
     resolve_inferer_roi_size,
     resolve_model_output_dtype,
 )
-from .tta import TTAPredictor
+
+
+def _coerce_tile_size(value) -> tuple[int, int]:
+    if isinstance(value, int):
+        return int(value), int(value)
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return int(value[0]), int(value[1])
+    raise ValueError(f"Tile metadata requires tile_size as int or [height, width], got {value!r}.")
+
+
+def _normalize_tile_patterns(patterns: Sequence[str], base_dir: Path) -> list[str]:
+    normalized = []
+    for pattern in patterns:
+        path = Path(str(pattern))
+        if not path.is_absolute():
+            path = base_dir / path
+        normalized.append(str(path))
+    return normalized
+
+
+def _load_tile_metadata_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        metadata = json.load(handle)
+    if not isinstance(metadata, dict):
+        raise ValueError(f"Tile metadata must be a JSON object, got {type(metadata).__name__}.")
+
+    image_patterns = metadata.get("image", metadata.get("images"))
+    if not image_patterns:
+        raise ValueError(f"Tile metadata {path} must contain an 'image' or 'images' list.")
+    if not isinstance(image_patterns, list):
+        raise ValueError(f"Tile metadata {path} image patterns must be a list.")
+
+    metadata = dict(metadata)
+    metadata["image"] = _normalize_tile_patterns(image_patterns, path.parent)
+    if "depth" not in metadata:
+        metadata["depth"] = len(metadata["image"])
+    for key in ("height", "width", "tile_size"):
+        if key not in metadata:
+            raise ValueError(f"Tile metadata {path} is missing required key '{key}'.")
+    metadata.setdefault("dtype", "uint8")
+    metadata.setdefault("tile_st", [0, 0])
+    metadata.setdefault("tile_ratio", 1.0)
+    return metadata
+
+
+def _infer_tile_metadata_from_directory(path: Path) -> dict:
+    section_dirs = sorted(
+        (p for p in path.iterdir() if p.is_dir() and p.name.isdigit()),
+        key=lambda item: int(item.name),
+    )
+    if not section_dirs:
+        raise ValueError(
+            f"Cannot infer tile metadata from {path}: expected numeric section directories."
+        )
+
+    first_section = section_dirs[0]
+    tile_files = sorted(first_section.glob("*_*.png"))
+    if not tile_files:
+        raise ValueError(
+            f"Cannot infer tile metadata from {path}: no '<row>_<column>.png' tiles found "
+            f"in {first_section}."
+        )
+
+    rows: list[int] = []
+    cols: list[int] = []
+    for tile_file in tile_files:
+        stem = tile_file.stem
+        try:
+            row_text, col_text = stem.split("_", 1)
+            rows.append(int(row_text))
+            cols.append(int(col_text))
+        except ValueError:
+            continue
+    if not rows or not cols:
+        raise ValueError(f"Cannot infer tile grid from {first_section}.")
+
+    from imageio.v2 import imread
+
+    sample = np.asarray(imread(tile_files[0]))
+    if sample.ndim < 2:
+        raise ValueError(f"Tile image {tile_files[0]} must be at least 2D, got {sample.shape}.")
+    tile_h, tile_w = int(sample.shape[0]), int(sample.shape[1])
+    row_min, row_max = min(rows), max(rows)
+    col_min, col_max = min(cols), max(cols)
+
+    return {
+        "image": [str(section_dir / "{row}_{column}.png") for section_dir in section_dirs],
+        "depth": len(section_dirs),
+        "height": (row_max - row_min + 1) * tile_h,
+        "width": (col_max - col_min + 1) * tile_w,
+        "tile_size": [tile_h, tile_w],
+        "dtype": str(sample.dtype),
+        "tile_st": [row_min, col_min],
+        "tile_ratio": 1.0,
+    }
+
+
+def _load_tile_metadata(source: str) -> dict:
+    path = Path(source)
+    if path.is_dir():
+        return _infer_tile_metadata_from_directory(path)
+    if path.suffix.lower() == ".json":
+        if path.exists():
+            return _load_tile_metadata_json(path)
+        sibling_dir = path.with_suffix("")
+        if sibling_dir.is_dir():
+            return _infer_tile_metadata_from_directory(sibling_dir)
+    raise ValueError(
+        f"Tile source {source} is neither an existing metadata JSON nor a tiled directory."
+    )
+
+
+def _is_tile_source(path: str) -> bool:
+    source = Path(path)
+    if ".zarr" in str(source):
+        return False
+    return source.suffix.lower() == ".json" or source.is_dir()
 
 
 def _normalize_transpose_axes(transpose_axes: Optional[Sequence[int]]) -> tuple[int, ...]:
@@ -344,10 +464,12 @@ class LazyVolumeAccessor:
         clip_percentile_high: float = 1.0,
         binarize: bool = False,
         threshold: float = 0.0,
+        tile_read_workers: int = 1,
     ):
         self.path = str(path)
         self.kind = kind
-        self.fmt = _detect_format(self.path)
+        self.tile_read_workers = max(1, int(tile_read_workers))
+        self.fmt = "tile" if _is_tile_source(self.path) else _detect_format(self.path)
         self.transpose_axes = _normalize_transpose_axes(transpose_axes)
         self.inverse_transpose_axes = _invert_transpose_axes(self.transpose_axes)
         self.scale_factors = (
@@ -364,6 +486,7 @@ class LazyVolumeAccessor:
         self._handle = None
         self._dataset = None
         self._tiff = None
+        self._tile_metadata = None
         self._open_handle()
 
         self.raw_shape = tuple(int(v) for v in self._get_raw_shape())
@@ -416,6 +539,8 @@ class LazyVolumeAccessor:
             import tifffile
 
             self._tiff = tifffile.TiffFile(self.path)
+        elif self.fmt == "tile":
+            self._tile_metadata = _load_tile_metadata(self.path)
         else:
             raise ValueError(
                 "Lazy sliding-window inference does not support format "
@@ -427,6 +552,15 @@ class LazyVolumeAccessor:
             return tuple(int(v) for v in self._dataset.shape)
         if self.fmt == "tiff":
             return tuple(int(v) for v in _get_tiff_volume_shape(self.path))
+        if self.fmt == "tile":
+            metadata = self._tile_metadata
+            if metadata is None:
+                raise RuntimeError("Tile metadata was not initialized.")
+            return (
+                int(metadata["depth"]),
+                int(metadata["height"]),
+                int(metadata["width"]),
+            )
         raise AssertionError("unreachable")
 
     @staticmethod
@@ -532,6 +666,41 @@ class LazyVolumeAccessor:
             return data[:, :, y_slice, x_slice]
         raise AssertionError("unreachable")
 
+    def _read_tile(self, raw_slices: tuple[slice, slice, slice]) -> np.ndarray:
+        from ..data.io.tiles import reconstruct_volume_from_tiles
+
+        metadata = self._tile_metadata
+        if metadata is None:
+            raise RuntimeError("Tile metadata was not initialized.")
+
+        z_slice, y_slice, x_slice = raw_slices
+        z0 = int(z_slice.start or 0)
+        y0 = int(y_slice.start or 0)
+        x0 = int(x_slice.start or 0)
+        z1 = int(z_slice.stop if z_slice.stop is not None else metadata["depth"])
+        y1 = int(y_slice.stop if y_slice.stop is not None else metadata["height"])
+        x1 = int(x_slice.stop if x_slice.stop is not None else metadata["width"])
+        tile_h, tile_w = _coerce_tile_size(metadata["tile_size"])
+
+        return reconstruct_volume_from_tiles(
+            tile_paths=metadata["image"],
+            volume_coords=[z0, z1, y0, y1, x0, x1],
+            tile_coords=[
+                0,
+                int(metadata["depth"]),
+                0,
+                int(metadata["height"]),
+                0,
+                int(metadata["width"]),
+            ],
+            tile_size=[tile_h, tile_w],
+            data_type=np.dtype(metadata.get("dtype", "uint8")),
+            tile_start=metadata.get("tile_st"),
+            tile_ratio=float(metadata.get("tile_ratio", 1.0)),
+            is_image=self.kind != "label",
+            num_workers=self.tile_read_workers,
+        )
+
     def _read_raw_crop(
         self, logical_start: Sequence[int], logical_end: Sequence[int]
     ) -> np.ndarray:
@@ -539,7 +708,9 @@ class LazyVolumeAccessor:
         if self.fmt in {"h5", "zarr"}:
             data = self._read_h5_or_zarr(raw_slices)
         else:
-            data = self._read_tiff(raw_slices)
+            data = (
+                self._read_tile(raw_slices) if self.fmt == "tile" else self._read_tiff(raw_slices)
+            )
 
         if self.layout == "no_channel":
             data = self._transpose_spatial_array(data)
@@ -778,6 +949,7 @@ def _build_accessor(cfg, path: str, *, kind: str, mode: str) -> LazyVolumeAccess
         clip_percentile_high=clip_high,
         binarize=binarize,
         threshold=threshold,
+        tile_read_workers=max(1, int(cfg.system.num_workers)),
     )
 
 

--- a/connectomics/models/losses/build.py
+++ b/connectomics/models/losses/build.py
@@ -33,6 +33,7 @@ from .losses import (
     WeightedMAELoss,
     WeightedMSELoss,
 )
+from .malis import MalisLoss
 from .metadata import (
     LossMetadata,
     attach_loss_metadata,
@@ -72,6 +73,7 @@ def _get_loss_registry() -> Dict[str, type[nn.Module]]:
         "PerChannelBCEWithLogitsLoss": PerChannelBCEWithLogitsLoss,
         "WeightedMSELoss": WeightedMSELoss,
         "WeightedMAELoss": WeightedMAELoss,
+        "MalisLoss": MalisLoss,
         "GANLoss": GANLoss,
         # Regularization losses
         "BinaryRegularization": BinaryRegularization,

--- a/connectomics/models/losses/malis.py
+++ b/connectomics/models/losses/malis.py
@@ -1,0 +1,336 @@
+"""PyTorch wrapper for the vendored MALIS affinity loss."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+_malis_lib: Any = None
+_MALIS_IMPORT_ERROR: BaseException | None = None
+
+try:
+    _malis_lib = importlib.import_module("malis")
+except Exception as _malis_import_exc:
+    _malis_lib = None
+    _MALIS_IMPORT_ERROR = _malis_import_exc
+
+
+class MalisLoss(nn.Module):
+    """Constrained MALIS loss for 3D affinity tensors.
+
+    v0 supports PyTC's canonical 3D affinity layout ``[B, C, Z, Y, X]`` only.
+    2D tensors are rejected explicitly because the vendored MALIS helpers operate
+    on 3D affinity graphs by default. See ``lib/malis/INVESTIGATION.md`` for
+    GPU MALIS candidates and algorithm-level speedup follow-ups.
+    """
+
+    def __init__(
+        self,
+        nhood: Sequence[Sequence[int]] | np.ndarray | torch.Tensor | None = None,
+        *,
+        reduction: str = "sum",
+        sigmoid: bool = True,
+        malis_crop_size: int | Sequence[int] | None = None,
+    ):
+        """Initialize the MALIS affinity loss.
+
+        Args:
+            nhood: 3D affinity neighborhood with shape ``(n_edge, 3)``.
+            reduction: ``"sum"``, ``"mean"``, or ``"none"``.
+            sigmoid: Apply sigmoid to ``pred`` before computing the loss.
+            malis_crop_size: Optional random shared spatial crop. ``None``
+                preserves current full-volume behavior. An int ``K`` becomes
+                ``(K, K, K)``; any length-3 integer sequence becomes
+                ``(Kz, Ky, Kx)``.
+        """
+        super().__init__()
+        if _malis_lib is None:
+            raise ImportError(
+                "MalisLoss requires the optional 'malis' package/extension. "
+                "Build or install the vendored library under lib/malis before "
+                "constructing this loss."
+            ) from _MALIS_IMPORT_ERROR
+        if reduction not in {"mean", "sum", "none"}:
+            raise ValueError(f"Unsupported reduction for MalisLoss: {reduction!r}")
+
+        self.reduction = reduction
+        self.sigmoid = sigmoid
+        self.nhood = self._coerce_nhood(nhood)
+        self.malis_crop_size = self._coerce_crop_size(malis_crop_size)
+        self._edge_list_cache: dict[tuple[int, int, int], tuple[np.ndarray, np.ndarray]] = {}
+
+    def forward(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compute MALIS-weighted squared affinity error.
+
+        The default ``reduction="sum"`` matches the vendored TensorFlow MALIS
+        implementation, which returns ``reduce_sum(weights * squared_error)``.
+        ``reduction="mean"`` and ``"none"`` follow standard PyTorch reduction
+        semantics over that weighted edge-loss tensor.
+
+        Args:
+            pred: Affinity logits by default, or affinities if ``sigmoid=False``.
+            target: Ground-truth affinities with shape ``[B, C, Z, Y, X]``.
+            mask: Optional binary edge mask for known ground-truth affinities.
+                Masked-out edges are excluded from MALIS pass constraints and
+                zeroed before per-pass normalization, but the mask does not
+                change GT connected-component reconstruction.
+        """
+        self._validate_inputs(pred, target)
+
+        pred_aff = torch.sigmoid(pred) if self.sigmoid else pred
+        target_aff = target.to(device=pred.device, dtype=pred_aff.dtype)
+        mask_aff = None if mask is None else self._prepare_mask(mask, pred_aff)
+        pred_aff, target_aff, mask_aff = self._apply_crop_if_configured(
+            pred_aff,
+            target_aff,
+            mask_aff,
+        )
+        weights = self._compute_malis_weights(
+            pred_aff.detach(),
+            target_aff.detach(),
+            None if mask_aff is None else mask_aff.detach(),
+        )
+
+        edge_loss = (pred_aff - target_aff) ** 2
+        weighted_loss = weights * edge_loss
+
+        if self.reduction == "none":
+            return weighted_loss
+        if self.reduction == "sum":
+            return weighted_loss.sum()
+        return weighted_loss.mean()
+
+    def _coerce_nhood(
+        self,
+        nhood: Sequence[Sequence[int]] | np.ndarray | torch.Tensor | None,
+    ) -> np.ndarray:
+        if nhood is None:
+            arr = _malis_lib.mknhood3d(1)
+        elif isinstance(nhood, torch.Tensor):
+            arr = nhood.detach().cpu().numpy()
+        else:
+            arr = np.asarray(nhood)
+
+        arr = np.ascontiguousarray(arr, dtype=np.int32)
+        if arr.ndim != 2 or arr.shape[1] != 3:
+            raise ValueError(
+                "MalisLoss v0 expects a 3D neighborhood with shape (n_edge, 3); "
+                f"got {tuple(arr.shape)}."
+            )
+        return arr
+
+    def _coerce_crop_size(
+        self,
+        value: int | Sequence[int] | None,
+    ) -> tuple[int, int, int] | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(
+                "malis_crop_size must be a positive int or length-3 sequence; " f"got {value!r}."
+            )
+        if isinstance(value, (int, np.integer)):
+            value_int = int(value)
+            if value_int <= 0:
+                raise ValueError(f"malis_crop_size scalar must be > 0; got {value!r}.")
+            return (value_int, value_int, value_int)
+        if isinstance(value, str):
+            raise ValueError(
+                "malis_crop_size must be int or length-3 int sequence, not str; " f"got {value!r}."
+            )
+
+        try:
+            seq = list(value)
+        except TypeError as e:
+            raise ValueError(
+                "malis_crop_size must be int or length-3 int sequence; " f"got {value!r}."
+            ) from e
+
+        if len(seq) != 3:
+            raise ValueError(
+                "malis_crop_size sequence must have length 3; "
+                f"got len={len(seq)} value={value!r}."
+            )
+
+        out: list[int] = []
+        for dim in seq:
+            if isinstance(dim, bool):
+                raise ValueError("malis_crop_size element must be a positive int; " f"got {dim!r}.")
+            if not isinstance(dim, (int, np.integer)):
+                raise ValueError(
+                    "malis_crop_size element must be int; "
+                    f"got {dim!r} (type {type(dim).__name__})."
+                )
+            dim_int = int(dim)
+            if dim_int <= 0:
+                raise ValueError(f"malis_crop_size element must be > 0; got {dim!r}.")
+            out.append(dim_int)
+
+        return (out[0], out[1], out[2])
+
+    def _validate_inputs(self, pred: torch.Tensor, target: torch.Tensor) -> None:
+        if pred.shape != target.shape:
+            raise ValueError(
+                "MalisLoss expects pred and target to have identical shapes; "
+                f"got pred={tuple(pred.shape)}, target={tuple(target.shape)}."
+            )
+        if pred.ndim == 4:
+            raise NotImplementedError(
+                "MalisLoss v0 supports 3D affinity tensors [B, C, Z, Y, X] only; "
+                "2D support requires a dedicated mknhood2d/nodelist_like path."
+            )
+        if pred.ndim != 5:
+            raise ValueError(
+                "MalisLoss expects 3D affinity tensors with shape [B, C, Z, Y, X]; "
+                f"got {tuple(pred.shape)}."
+            )
+        if pred.shape[1] != self.nhood.shape[0]:
+            raise ValueError(
+                "MalisLoss channel count must match nhood edges; "
+                f"got C={pred.shape[1]}, nhood_edges={self.nhood.shape[0]}."
+            )
+
+    def _prepare_mask(self, mask: torch.Tensor, pred: torch.Tensor) -> torch.Tensor:
+        mask_tensor = mask.to(device=pred.device, dtype=pred.dtype)
+        if mask_tensor.ndim == pred.ndim - 1 and mask_tensor.shape[0] == pred.shape[0]:
+            mask_tensor = mask_tensor.unsqueeze(1)
+        try:
+            return torch.broadcast_to(mask_tensor, pred.shape)
+        except RuntimeError as e:
+            raise ValueError(
+                "MalisLoss mask shape is not broadcastable to pred shape: "
+                f"mask={tuple(mask.shape)}, pred={tuple(pred.shape)}."
+            ) from e
+
+    def _apply_crop_if_configured(
+        self,
+        pred_aff: torch.Tensor,
+        target_aff: torch.Tensor,
+        mask_aff: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Apply the configured random sub-volume crop, if any.
+
+        Offset sampling stays on CPU. The returned tensors are contiguous copies
+        of the narrowed views; this is required because the downstream CPU MALIS
+        path eventually calls ``.cpu().numpy()``. Gradient still flows through
+        the contiguous copies back to the original ``pred``. For B=2, C=3,
+        crop=64, and fp16, pred + target + mask copies are about 9 MiB before
+        overhead.
+
+        Returns ``(pred_cropped, target_cropped, mask_cropped)``. If no crop is
+        configured the inputs are returned unchanged.
+        """
+        if self.malis_crop_size is None:
+            return pred_aff, target_aff, mask_aff
+
+        k_z, k_y, k_x = self.malis_crop_size
+        z_dim, y_dim, x_dim = pred_aff.shape[-3:]
+        if k_z > z_dim or k_y > y_dim or k_x > x_dim:
+            raise ValueError(
+                "malis_crop_size exceeds spatial dims: "
+                f"crop={self.malis_crop_size}, input_zyx=({z_dim},{y_dim},{x_dim})."
+            )
+
+        z0 = int(torch.randint(0, z_dim - k_z + 1, (1,)).item())
+        y0 = int(torch.randint(0, y_dim - k_y + 1, (1,)).item())
+        x0 = int(torch.randint(0, x_dim - k_x + 1, (1,)).item())
+
+        pred_c = pred_aff.narrow(-3, z0, k_z).narrow(-2, y0, k_y).narrow(-1, x0, k_x).contiguous()
+        target_c = (
+            target_aff.narrow(-3, z0, k_z).narrow(-2, y0, k_y).narrow(-1, x0, k_x).contiguous()
+        )
+        mask_c = (
+            None
+            if mask_aff is None
+            else mask_aff.narrow(-3, z0, k_z).narrow(-2, y0, k_y).narrow(-1, x0, k_x).contiguous()
+        )
+        return pred_c, target_c, mask_c
+
+    def _compute_malis_weights(
+        self,
+        pred_aff: torch.Tensor,
+        target_aff: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        pred_np = pred_aff.to(dtype=torch.float32).cpu().numpy()
+        target_np = target_aff.to(dtype=torch.float32).cpu().numpy()
+        mask_np = None if mask is None else mask.to(dtype=torch.float32).cpu().numpy()
+        weights = np.empty_like(pred_np, dtype=np.float32)
+        for batch_idx in range(pred_np.shape[0]):
+            gt_affs = np.ascontiguousarray(target_np[batch_idx] > 0.5, dtype=np.int32)
+            pred_sample = np.ascontiguousarray(pred_np[batch_idx], dtype=np.float32)
+            mask_sample = None
+            if mask_np is not None:
+                mask_sample = np.ascontiguousarray(mask_np[batch_idx] == 1, dtype=bool)
+            gt_seg, _ = _malis_lib.connected_components_affgraph(gt_affs, self.nhood)
+            weights[batch_idx] = self._compute_sample_weights(
+                pred_sample,
+                gt_affs,
+                gt_seg,
+                mask_sample,
+            )
+
+        return torch.from_numpy(weights).to(device=pred_aff.device, dtype=pred_aff.dtype)
+
+    def _compute_sample_weights(
+        self,
+        pred_affs: np.ndarray,
+        gt_affs: np.ndarray,
+        gt_seg: np.ndarray,
+        mask: np.ndarray | None,
+    ) -> np.ndarray:
+        weights_neg = self._malis_pass(pred_affs, gt_affs, gt_seg, mask, pos=0)
+        weights_pos = self._malis_pass(pred_affs, gt_affs, gt_seg, mask, pos=1)
+        return weights_neg + weights_pos
+
+    def _malis_pass(
+        self,
+        pred_affs: np.ndarray,
+        gt_affs: np.ndarray,
+        gt_seg: np.ndarray,
+        mask: np.ndarray | None,
+        *,
+        pos: int,
+    ) -> np.ndarray:
+        pass_affs = np.array(pred_affs, copy=True)
+        class_edges = gt_affs == (1 - pos)
+        constraint_edges = class_edges if mask is None else class_edges & mask
+        pass_affs[constraint_edges] = 1 - pos
+
+        node1, node2 = self._edge_list_for_shape(gt_seg.shape)
+        weights = _malis_lib.malis_loss_weights(
+            np.ascontiguousarray(gt_seg, dtype=np.uint64).ravel(),
+            node1.ravel(),
+            node2.ravel(),
+            np.ascontiguousarray(pass_affs, dtype=np.float32).ravel(),
+            pos,
+        )
+        weights = weights.reshape((-1,) + tuple(gt_seg.shape)).astype(np.float32, copy=False)
+        weights[class_edges] = 0.0
+        if mask is not None:
+            weights[~mask] = 0.0
+
+        num_pairs = weights.sum(dtype=np.float64)
+        if num_pairs > 0:
+            weights = weights / np.float32(num_pairs)
+        return weights
+
+    def _edge_list_for_shape(self, shape: tuple[int, int, int]) -> tuple[np.ndarray, np.ndarray]:
+        cached = self._edge_list_cache.get(shape)
+        if cached is None:
+            node1, node2 = _malis_lib.nodelist_like(shape, self.nhood)
+            cached = (
+                np.ascontiguousarray(node1, dtype=np.uint64),
+                np.ascontiguousarray(node2, dtype=np.uint64),
+            )
+            self._edge_list_cache[shape] = cached
+        return cached

--- a/connectomics/models/losses/metadata.py
+++ b/connectomics/models/losses/metadata.py
@@ -43,6 +43,7 @@ _LOSS_METADATA_BY_NAME = {
     ),
     "WeightedMSELoss": LossMetadata("WeightedMSELoss", spatial_weight_arg="weight"),
     "WeightedMAELoss": LossMetadata("WeightedMAELoss", spatial_weight_arg="weight"),
+    "MalisLoss": LossMetadata("MalisLoss", spatial_weight_arg="mask"),
     # GAN is not compatible with the generic supervised orchestrator path
     "GANLoss": LossMetadata("GANLoss", call_kind="unsupported", target_kind="none"),
     # Regularization losses

--- a/connectomics/runtime/cache_resolver.py
+++ b/connectomics/runtime/cache_resolver.py
@@ -16,7 +16,7 @@ from .output_naming import (
     is_raw_cache_suffix,
     resolve_prediction_cache_suffix,
 )
-from .sharding import resolve_test_image_paths
+from .sharding import is_chunked_raw_inference, resolve_test_image_paths
 
 
 def resolve_cached_prediction_files(
@@ -281,6 +281,13 @@ def try_cache_only_test_execution(
 ) -> bool:
     """Run cache-only test path before model/trainer/datamodule creation when possible."""
     if mode != "test":
+        return False
+    # Chunked raw-prediction inference caches per chunk (skip-on-exists lives
+    # inside the chunked path) and shards by chunk grid, not by whole volume.
+    # The whole-volume cache-only path here does not model per-chunk artifacts,
+    # and under --shard-id/--num-shards its volume sharding would strand every
+    # shard but shard 0 for a single-volume input. Let the chunked path own it.
+    if is_chunked_raw_inference(cfg):
         return False
     data_cfg = getattr(cfg, "data", None)
     if data_cfg is None:

--- a/connectomics/runtime/dispatch.py
+++ b/connectomics/runtime/dispatch.py
@@ -31,6 +31,7 @@ from .output_naming import resolve_prediction_cache_suffix
 from .sharding import (
     has_assigned_test_shard,
     maybe_enable_independent_test_sharding,
+    maybe_enable_naive_chunk_sharding,
     maybe_limit_test_devices,
     resolve_test_stage_runtime,
     shard_test_datamodule,
@@ -188,7 +189,9 @@ def _run_test(
         checkpoint_path=args.checkpoint,
     )
 
-    if maybe_enable_independent_test_sharding(args, cfg):
+    naive_chunk_sharding = maybe_enable_naive_chunk_sharding(args, cfg)
+
+    if not naive_chunk_sharding and maybe_enable_independent_test_sharding(args, cfg):
         trainer = create_trainer(
             cfg,
             run_dir=run_dir,
@@ -208,7 +211,7 @@ def _run_test(
         print("Loading test data...")
         datamodule = create_datamodule(cfg, mode="test")
 
-    if args.shard_id is not None and args.num_shards is not None:
+    if not naive_chunk_sharding and args.shard_id is not None and args.num_shards is not None:
         datamodule = shard_test_datamodule(datamodule, args.shard_id, args.num_shards)
 
     if maybe_limit_test_devices(cfg, datamodule):

--- a/connectomics/runtime/sharding.py
+++ b/connectomics/runtime/sharding.py
@@ -13,6 +13,45 @@ from ..config.pipeline import resolve_data_paths
 from .output_naming import compute_tta_passes
 
 
+def is_chunked_raw_inference(cfg: Config) -> bool:
+    inference_cfg = getattr(cfg, "inference", None)
+    chunking_cfg = getattr(inference_cfg, "chunking", None)
+    return bool(
+        str(getattr(inference_cfg, "strategy", "whole_volume")).lower() == "chunked"
+        and getattr(chunking_cfg, "enabled", False)
+        and str(getattr(chunking_cfg, "output_mode", "decoded")).lower() == "raw_prediction"
+    )
+
+
+def maybe_enable_naive_chunk_sharding(args: Any, cfg: Config) -> bool:
+    """Map --shard-id/--num-shards to chunk-grid sharding for one-volume raw inference."""
+    shard_id = getattr(args, "shard_id", None)
+    num_shards = getattr(args, "num_shards", None)
+    if shard_id is None and num_shards is None:
+        return False
+    if not is_chunked_raw_inference(cfg):
+        return False
+    if shard_id is None or num_shards is None:
+        raise ValueError("--shard-id and --num-shards must be provided together.")
+
+    shard_id = int(shard_id)
+    num_shards = int(num_shards)
+    if num_shards <= 0:
+        raise ValueError(f"--num-shards must be positive, got {num_shards}.")
+    if shard_id < 0 or shard_id >= num_shards:
+        raise ValueError(f"--shard-id={shard_id} out of range for --num-shards={num_shards}.")
+
+    chunking_cfg = cfg.inference.chunking
+    chunking_cfg.shard_id = shard_id
+    chunking_cfg.num_shards = num_shards
+    cfg.system.num_gpus = 1 if torch.cuda.is_available() else 0
+    print(
+        "  INFO: Naive chunk sharding enabled for chunked raw inference "
+        f"(shard {shard_id}/{num_shards}); this job will not use torch.distributed."
+    )
+    return True
+
+
 def resolve_test_stage_runtime(cfg: Config) -> Config:
     """Switch runtime config to test stage and re-resolve resource sentinels."""
     cfg = resolve_default_profiles(cfg, mode="test")
@@ -65,13 +104,7 @@ def maybe_limit_test_devices(cfg: Config, datamodule: Any) -> bool:
     distributed_window_sharding = bool(
         is_lazy and getattr(sliding_cfg, "distributed_sharding", False)
     )
-    inference_cfg = getattr(cfg, "inference", None)
-    chunking_cfg = getattr(inference_cfg, "chunking", None)
-    distributed_chunked_raw = bool(
-        str(getattr(inference_cfg, "strategy", "whole_volume")).lower() == "chunked"
-        and getattr(chunking_cfg, "enabled", False)
-        and str(getattr(chunking_cfg, "output_mode", "decoded")).lower() == "raw_prediction"
-    )
+    distributed_chunked_raw = is_chunked_raw_inference(cfg)
     if distributed_tta_sharding and test_volume_count != 1:
         print(
             "  WARNING: Disabling distributed TTA sharding for multi-volume test datasets. "
@@ -177,6 +210,9 @@ def maybe_enable_independent_test_sharding(args: Any, cfg: Config) -> bool:
     num_shards = getattr(args, "num_shards", None)
     source = None
 
+    if is_chunked_raw_inference(cfg) and shard_id is not None and num_shards is not None:
+        return False
+
     if shard_id is not None and num_shards is not None and int(num_shards) > 1:
         source = "explicit shard arguments"
     else:
@@ -214,6 +250,8 @@ def has_assigned_test_shard(cfg: Config, args: Any) -> bool:
     shard_id = getattr(args, "shard_id", None)
     num_shards = getattr(args, "num_shards", None)
     if shard_id is None or num_shards is None:
+        return True
+    if is_chunked_raw_inference(cfg):
         return True
 
     test_image_paths = resolve_test_image_paths(cfg)
@@ -256,7 +294,9 @@ def shard_test_datamodule(datamodule: Any, shard_id: int, num_shards: int):
 __all__ = [
     "estimate_tta_total_passes",
     "has_assigned_test_shard",
+    "is_chunked_raw_inference",
     "maybe_enable_independent_test_sharding",
+    "maybe_enable_naive_chunk_sharding",
     "maybe_limit_test_devices",
     "resolve_test_image_paths",
     "resolve_test_rank_shard_from_env",

--- a/connectomics/training/lightning/data_factory.py
+++ b/connectomics/training/lightning/data_factory.py
@@ -375,10 +375,24 @@ def create_datamodule(
                 list_datasets()
                 raise FileNotFoundError(f"Training data not found: {cfg.data.train.image}")
 
+    def _dataset_type_for_mode() -> str | None:
+        if mode == "test":
+            return (
+                getattr(cfg.data.test, "dataset_type", None)
+                or getattr(cfg.data.train, "dataset_type", None)
+                or getattr(cfg.data.val, "dataset_type", None)
+            )
+        if mode == "tune":
+            return getattr(cfg.data.val, "dataset_type", None) or getattr(
+                cfg.data.train, "dataset_type", None
+            )
+        return getattr(cfg.data.train, "dataset_type", None) or getattr(
+            cfg.data.val, "dataset_type", None
+        )
+
     # Check dataset type early
-    dataset_type = getattr(cfg.data.train, "dataset_type", None) or getattr(
-        cfg.data.val, "dataset_type", None
-    )
+    dataset_type = _dataset_type_for_mode()
+    dataset_type_name = str(dataset_type).lower() if dataset_type else None
 
     # Auto-precompute label_aux (skeleton/SDT) before building transforms so the
     # active splits include label_aux in their load/crop pipeline.
@@ -395,6 +409,7 @@ def create_datamodule(
         and (
             getattr(dataloader_cfg, "use_lazy_zarr", False)
             or getattr(dataloader_cfg, "use_lazy_h5", False)
+            or dataset_type_name == "tile"
         )
     )
     if lazy_test_inference:
@@ -595,14 +610,23 @@ def create_datamodule(
     test_data_dicts = None
     if mode == "test":
         split = cfg.data.test
+        split_dataset_type = str(getattr(split, "dataset_type", "") or "").lower()
         # Skip image validation when using decoding.load_prediction_path (decode-only)
         _saved = getattr(getattr(cfg, "decoding", None), "load_prediction_path", "")
-        if not split.image and not _saved:
+        if split_dataset_type == "tile":
+            tile_source = split.json or split.image
+            if not tile_source:
+                raise ValueError(
+                    "Tile test mode requires data.test.image or data.test.json to be set."
+                )
+            logger.info(f"Creating test tile dataset from: {tile_source}")
+            test_image_paths = expand_file_paths(tile_source)
+        elif not split.image and not _saved:
             raise ValueError(
                 "Test mode requires data.test.image to be set.\n"
                 f"Current resolved image = {split.image}"
             )
-        if split.image:
+        elif split.image:
             logger.info(f"Creating test dataset from: {split.image}")
             test_image_paths = expand_file_paths(split.image)
         else:
@@ -616,16 +640,25 @@ def create_datamodule(
         test_mask_paths = expand_file_paths(split.mask) if split.mask else None
     elif mode == "tune":
         split = cfg.data.val
-        if not split.image:
+        split_dataset_type = str(getattr(split, "dataset_type", "") or "").lower()
+        if split_dataset_type == "tile":
+            tile_source = split.json or split.image
+            if not tile_source:
+                raise ValueError(
+                    "Tile tune mode requires data.val.image or data.val.json to be set."
+                )
+            logger.info(f"Creating tune tile dataset from: {tile_source}")
+            test_image_paths = expand_file_paths(tile_source)
+        elif not split.image:
             raise ValueError(
                 "Tune mode requires data.val.image to be set.\n"
                 f"Current resolved val.image = {getattr(cfg.data.val, 'image', None)}"
             )
+        else:
+            logger.info(f"Creating tune dataset from: {split.image}")
 
-        logger.info(f"Creating tune dataset from: {split.image}")
-
-        # Expand glob patterns for tune data
-        test_image_paths = expand_file_paths(split.image)
+            # Expand glob patterns for tune data
+            test_image_paths = expand_file_paths(split.image)
         test_label_paths = expand_file_paths(split.label) if split.label else None
         test_label_aux_paths = expand_file_paths(split.label_aux) if split.label_aux else None
         test_mask_paths = expand_file_paths(split.mask) if split.mask else None

--- a/connectomics/training/lightning/test_pipeline.py
+++ b/connectomics/training/lightning/test_pipeline.py
@@ -21,6 +21,7 @@ from ...evaluation import EvaluationContext, evaluation_metric_requested, run_ev
 from ...inference import (
     apply_prediction_transform,
     is_chunked_inference_enabled,
+    is_external_chunk_sharding_enabled,
     run_chunked_prediction_inference,
     run_prediction_inference,
     write_outputs,
@@ -310,11 +311,13 @@ def _process_decoding_postprocessing(
     if save_intermediate:
         ckpt_path = module._get_prediction_checkpoint_path()
 
-        def on_step_complete(batch_idx: int, step: Any, sample: np.ndarray) -> None:
+        def _on_decode_step_complete(batch_idx: int, step: Any, sample: np.ndarray) -> None:
             suffix = intermediate_decode_step_output_tag(
                 module.cfg, step, checkpoint_path=ckpt_path
             )
             write_decoded_outputs(module.cfg, sample, filenames, suffix=suffix)
+
+        on_step_complete = _on_decode_step_complete
 
     result = run_decoding_stage(module.cfg, predictions_np, on_step_complete=on_step_complete)
     decoded_predictions = result.decoded
@@ -728,11 +731,17 @@ def run_test_step(module, batch: Dict[str, torch.Tensor], batch_idx: int) -> STE
             volume_dir.mkdir(parents=True, exist_ok=True)
             output_path = volume_dir / raw_filename
             crop_pad = resolve_global_prediction_crop(module.cfg)
-            qc_acc = begin_streaming_qc(
-                module.cfg,
-                channel_count=int(module.cfg.model.out_channels),
-                z_extent=int(reference_image_shape[-3])
-                - int(crop_pad[0][0]) - int(crop_pad[0][1]),
+            external_chunk_shard = is_external_chunk_sharding_enabled(module.cfg)
+            qc_acc = (
+                None
+                if external_chunk_shard
+                else begin_streaming_qc(
+                    module.cfg,
+                    channel_count=int(module.cfg.model.out_channels),
+                    z_extent=int(reference_image_shape[-3])
+                    - int(crop_pad[0][0])
+                    - int(crop_pad[0][1]),
+                )
             )
             output_path = run_chunked_prediction_inference(
                 module.cfg,
@@ -746,6 +755,15 @@ def run_test_step(module, batch: Dict[str, torch.Tensor], batch_idx: int) -> STE
                 requested_head=selected_output_head,
                 qc_streaming_callback=qc_acc,
             )
+            if external_chunk_shard:
+                logger.info(
+                    "Naive chunk shard completed; wrote assigned chunk files under %s. "
+                    "Run scripts/stitch_chunked_prediction.py after all shards finish.",
+                    output_path,
+                )
+                _cleanup_inference_memory(module, "naive chunk raw shard", release_model=True)
+                _log_volume_header(volume_name, "VOLUME COMPLETE")
+                return torch.tensor(0.0, device=module.device)
             should_finalize_qc = True
             if torch.distributed.is_available() and torch.distributed.is_initialized():
                 if torch.distributed.get_world_size() > 1 and torch.distributed.get_rank() != 0:

--- a/scripts/tiles_to_zarr.py
+++ b/scripts/tiles_to_zarr.py
@@ -1,0 +1,257 @@
+"""Convert a tiled PNG volume (e.g. zebrafinch im_align_10nm) to a multiscale OME-Zarr.
+
+Why: the tiled-PNG reader decodes a full 4096x4096 PNG per z-section for every
+ROI, so large-volume inference spends most of its wall-time at 0% GPU. Converting
+once to a chunked, compressed zarr makes reads true random-access and lets the GPU
+stay fed. The output is an OME-NGFF multiscale group (full-res + 2x/4x/8x ...),
+directly usable by inference (`data.test.image: <out>.zarr/0`), neuroglancer, and
+napari.
+
+Workflow (the destructive `remove-png` step is intentionally separate and gated):
+
+    # 1. create the group + per-level arrays + OME metadata (run once)
+    python scripts/tiles_to_zarr.py --source SRC --output OUT.zarr --stage init
+
+    # 2. fill full resolution from the PNGs (shard across the cluster)
+    python scripts/tiles_to_zarr.py --source SRC --output OUT.zarr --stage base \
+        --shard-id $i --num-shards $N --workers 16
+
+    # 3. build the downsampled pyramid from level 0 (cheap; single job is fine)
+    python scripts/tiles_to_zarr.py --source SRC --output OUT.zarr --stage pyramid
+
+    # 4. verify level 0 byte-for-byte against the PNGs (shard across the cluster)
+    python scripts/tiles_to_zarr.py --source SRC --output OUT.zarr --stage verify \
+        --shard-id $i --num-shards $N --workers 16
+
+    # 5. ONLY after every verify shard signed off: delete the raw PNGs
+    python scripts/tiles_to_zarr.py --source SRC --output OUT.zarr --stage remove-png \
+        --num-shards $N --yes
+
+Steps 2 and 4 slot directly into `just slurm-sharded` (one task per shard id).
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+from connectomics.data.io.tiles import reconstruct_volume_from_tiles
+from connectomics.inference.lazy import _load_tile_metadata
+
+VERIFY_DIR = "_verify_ok"
+
+
+def _level_shapes(base_shape: tuple[int, int, int], levels: int) -> list[tuple[int, int, int]]:
+    shapes = [tuple(int(v) for v in base_shape)]
+    for _ in range(1, levels):
+        prev = shapes[-1]
+        shapes.append(tuple(max(1, math.ceil(n / 2)) for n in prev))
+    return shapes
+
+
+def _iter_blocks(shape, block):
+    """Yield (zslice, yslice, xslice) covering `shape` in `block`-sized tiles."""
+    zb, yb, xb = block
+    for z0 in range(0, shape[0], zb):
+        for y0 in range(0, shape[1], yb):
+            for x0 in range(0, shape[2], xb):
+                yield (
+                    slice(z0, min(z0 + zb, shape[0])),
+                    slice(y0, min(y0 + yb, shape[1])),
+                    slice(x0, min(x0 + xb, shape[2])),
+                )
+
+
+def _my_blocks(blocks, shard_id, num_shards):
+    return [b for i, b in enumerate(blocks) if i % num_shards == shard_id]
+
+
+def _read_source_block(meta, block) -> np.ndarray:
+    """Decode the source PNG region for `block` (parallel over z-sections)."""
+    tile_h, tile_w = (int(meta["tile_size"][0]), int(meta["tile_size"][1])) \
+        if isinstance(meta["tile_size"], (list, tuple)) else (int(meta["tile_size"]),) * 2
+    zs, ys, xs = block
+    return reconstruct_volume_from_tiles(
+        tile_paths=meta["image"],
+        volume_coords=[zs.start, zs.stop, ys.start, ys.stop, xs.start, xs.stop],
+        tile_coords=[0, int(meta["depth"]), 0, int(meta["height"]), 0, int(meta["width"])],
+        tile_size=[tile_h, tile_w],
+        data_type=np.dtype(meta.get("dtype", "uint8")),
+        tile_start=meta.get("tile_st", [0, 0]),
+        tile_ratio=float(meta.get("tile_ratio", 1.0)),
+        is_image=True,
+        num_workers=int(os.environ.get("TILE_READ_WORKERS", "1")),
+    )
+
+
+def _png_file_list(meta) -> list[str]:
+    """Expand the tile patterns into concrete source PNG paths."""
+    tile_h, tile_w = int(meta["tile_size"][0]), int(meta["tile_size"][1])
+    n_rows = int(meta["height"]) // tile_h
+    n_cols = int(meta["width"]) // tile_w
+    r0, c0 = meta.get("tile_st", [0, 0])
+    files = []
+    for pattern in meta["image"]:
+        if "{row}_{column}" in pattern:
+            for r in range(n_rows):
+                for c in range(n_cols):
+                    files.append(pattern.format(row=r + r0, column=c + c0))
+        else:
+            files.append(pattern)
+    return files
+
+
+def stage_init(args, meta):
+    import numcodecs
+    import zarr
+
+    base_shape = (int(meta["depth"]), int(meta["height"]), int(meta["width"]))
+    shapes = _level_shapes(base_shape, args.levels)
+    if os.path.exists(args.output) and not args.force:
+        raise SystemExit(f"{args.output} exists; pass --force to recreate metadata/arrays.")
+    compressor = numcodecs.Blosc(cname="zstd", clevel=3, shuffle=numcodecs.Blosc.SHUFFLE)
+    root = zarr.open_group(args.output, mode="a")
+    for level, shp in enumerate(shapes):
+        chunks = tuple(min(c, s) for c, s in zip(args.chunk, shp))
+        root.create_dataset(
+            str(level), shape=shp, chunks=chunks, dtype="uint8",
+            compressor=compressor, overwrite=args.force, fill_value=0,
+        )
+    res = [float(r) for r in args.resolution]
+    root.attrs["multiscales"] = [{
+        "version": "0.4",
+        "name": Path(args.output).stem,
+        "axes": [{"name": a, "type": "space", "unit": "nanometer"} for a in ("z", "y", "x")],
+        "datasets": [
+            {"path": str(l),
+             "coordinateTransformations": [{"type": "scale", "scale": [r * (2 ** l) for r in res]}]}
+            for l in range(args.levels)
+        ],
+    }]
+    print(f"Initialized {args.output} with {args.levels} levels:")
+    for l, shp in enumerate(shapes):
+        print(f"  level {l}: shape={shp} chunks={tuple(min(c, s) for c, s in zip(args.chunk, shp))}")
+
+
+def stage_base(args, meta):
+    import zarr
+
+    os.environ["TILE_READ_WORKERS"] = str(args.workers)
+    arr = zarr.open(args.output, mode="r+")["0"]
+    blocks = list(_iter_blocks(arr.shape, (args.z_block, args.xy_block, args.xy_block)))
+    mine = _my_blocks(blocks, args.shard_id, args.num_shards)
+    print(f"[base shard {args.shard_id}/{args.num_shards}] {len(mine)}/{len(blocks)} blocks")
+    for n, block in enumerate(mine):
+        arr[block] = _read_source_block(meta, block)
+        if n % 5 == 0 or n == len(mine) - 1:
+            print(f"  wrote block {n + 1}/{len(mine)} z={block[0]} y={block[1]} x={block[2]}", flush=True)
+
+
+def stage_pyramid(args, meta):
+    from skimage.measure import block_reduce
+    import zarr
+
+    root = zarr.open(args.output, mode="r+")
+    levels = range(1, args.levels) if args.level is None else [args.level]
+    for level in levels:
+        src, dst = root[str(level - 1)], root[str(level)]
+        blocks = list(_iter_blocks(dst.shape, (args.z_block, args.xy_block, args.xy_block)))
+        mine = _my_blocks(blocks, args.shard_id, args.num_shards)
+        print(f"[pyramid L{level} shard {args.shard_id}/{args.num_shards}] {len(mine)}/{len(blocks)} blocks")
+        for n, (zs, ys, xs) in enumerate(mine):
+            region = src[2 * zs.start: min(2 * zs.stop, src.shape[0]),
+                         2 * ys.start: min(2 * ys.stop, src.shape[1]),
+                         2 * xs.start: min(2 * xs.stop, src.shape[2])]
+            down = block_reduce(region.astype(np.float32), (2, 2, 2), np.mean)
+            down = np.round(down).astype(np.uint8)[: zs.stop - zs.start, : ys.stop - ys.start, : xs.stop - xs.start]
+            dst[zs, ys, xs] = down
+            if n % 5 == 0 or n == len(mine) - 1:
+                print(f"  L{level} block {n + 1}/{len(mine)}", flush=True)
+
+
+def stage_verify(args, meta):
+    import zarr
+
+    os.environ["TILE_READ_WORKERS"] = str(args.workers)
+    arr = zarr.open(args.output, mode="r")["0"]
+    base_shape = (int(meta["depth"]), int(meta["height"]), int(meta["width"]))
+    if tuple(arr.shape) != base_shape:
+        raise SystemExit(f"shape mismatch: zarr {tuple(arr.shape)} vs source {base_shape}")
+    blocks = list(_iter_blocks(arr.shape, (args.z_block, args.xy_block, args.xy_block)))
+    mine = _my_blocks(blocks, args.shard_id, args.num_shards)
+    print(f"[verify shard {args.shard_id}/{args.num_shards}] {len(mine)}/{len(blocks)} blocks")
+    for n, block in enumerate(mine):
+        if not np.array_equal(arr[block], _read_source_block(meta, block)):
+            raise SystemExit(f"MISMATCH at z={block[0]} y={block[1]} x={block[2]} — do NOT delete PNGs")
+        if n % 5 == 0 or n == len(mine) - 1:
+            print(f"  verified block {n + 1}/{len(mine)}", flush=True)
+    ok_dir = Path(args.output) / VERIFY_DIR
+    ok_dir.mkdir(exist_ok=True)
+    (ok_dir / f"shard_{args.shard_id}_of_{args.num_shards}.ok").write_text("ok\n")
+    print(f"[verify shard {args.shard_id}] OK")
+
+
+def stage_remove_png(args, meta):
+    if not args.yes:
+        raise SystemExit("Refusing to delete PNGs without --yes.")
+    ok_dir = Path(args.output) / VERIFY_DIR
+    missing = [i for i in range(args.num_shards)
+               if not (ok_dir / f"shard_{i}_of_{args.num_shards}.ok").exists()]
+    if missing:
+        raise SystemExit(
+            f"Refusing to delete: verify sign-off missing for shards {missing} "
+            f"(expected {args.num_shards} '.ok' files in {ok_dir}). Run --stage verify first."
+        )
+    files = [f for f in _png_file_list(meta) if os.path.exists(f)]
+    print(f"All {args.num_shards} verify shards signed off. Deleting {len(files)} PNG files...")
+    for n, f in enumerate(files):
+        os.remove(f)
+        if n % 5000 == 0:
+            print(f"  removed {n}/{len(files)}", flush=True)
+    # Drop now-empty section directories.
+    for d in sorted({os.path.dirname(f) for f in files}):
+        if os.path.isdir(d) and not os.listdir(d):
+            os.rmdir(d)
+    print(f"Removed {len(files)} PNG files.")
+
+
+STAGES = {
+    "init": stage_init, "base": stage_base, "pyramid": stage_pyramid,
+    "verify": stage_verify, "remove-png": stage_remove_png,
+}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--source", required=True, help="Tile metadata JSON or tiled directory.")
+    p.add_argument("--output", required=True, help="Output .zarr path.")
+    p.add_argument("--stage", required=True, choices=list(STAGES))
+    p.add_argument("--levels", type=int, default=4, help="Number of pyramid levels (full-res + downsamples).")
+    p.add_argument("--chunk", type=int, nargs=3, default=[128, 128, 128])
+    p.add_argument("--z-block", type=int, default=128, help="Z extent of a write block (multiple of chunk z).")
+    p.add_argument("--xy-block", type=int, default=4096, help="Y/X extent of a write block (multiple of chunk).")
+    p.add_argument("--resolution", type=float, nargs=3, default=[10.0, 10.0, 10.0], help="Level-0 voxel size (nm).")
+    p.add_argument("--workers", type=int, default=16, help="Threads for PNG decode in base/verify.")
+    p.add_argument("--level", type=int, default=None, help="pyramid: build only this level (for sharding).")
+    p.add_argument("--shard-id", type=int, default=0)
+    p.add_argument("--num-shards", type=int, default=1)
+    p.add_argument("--force", action="store_true", help="init: overwrite existing arrays.")
+    p.add_argument("--yes", action="store_true", help="remove-png: confirm deletion.")
+    args = p.parse_args()
+
+    for name, value in (("z_block", args.z_block), ("xy_block", args.xy_block)):
+        if value % min(args.chunk) != 0 and value % args.chunk[0] != 0:
+            print(f"  WARNING: --{name.replace('_', '-')}={value} is not chunk-aligned; "
+                  "sharded writes may touch shared chunks and race.")
+
+    meta = _load_tile_metadata(args.source)
+    STAGES[args.stage](args, meta)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_chunked_inference.py
+++ b/tests/unit/test_chunked_inference.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 import torch
 
+from connectomics.chunked.chunk_grid import build_chunk_grid
 from connectomics.config import Config, validate_config
 from connectomics.data.io import write_hdf5
 from connectomics.decoding.streamed_chunked import UnionFind, _union_face_pairs
-from connectomics.chunked.chunk_grid import build_chunk_grid
 from connectomics.inference.chunk_grid import (
     resolve_global_prediction_crop,
     validate_chunked_output_format,
@@ -18,9 +18,11 @@ from connectomics.inference.chunked import (
     _per_chunk_dir,
     _run_chunked_prediction_per_rank,
     _stitch_chunk_prediction_files,
+    is_external_chunk_sharding_enabled,
     run_chunked_prediction_inference,
 )
 from connectomics.inference.lazy import lazy_predict_volume
+from scripts.stitch_chunked_prediction import stitch
 
 
 def _patch_mean_forward(x: torch.Tensor) -> torch.Tensor:
@@ -262,3 +264,58 @@ def test_per_rank_chunk_artifacts_use_chunk_local_shape_metadata(tmp_path):
     assert json.loads(attrs["final_shape"]) == [2, 4, 7]
     assert json.loads(attrs["chunk_shape"]) == [2, 4, 7]
     assert "crop_pad" not in attrs
+
+
+def test_external_chunk_shards_write_chunks_without_stitching_then_script_stitches(tmp_path):
+    cfg = Config()
+    cfg.data.image_transform.normalize = "none"
+    cfg.data.dataloader.patch_size = [3, 3, 3]
+    cfg.data.dataloader.batch_size = 2
+    cfg.model.output_size = [3, 3, 3]
+    cfg.inference.strategy = "chunked"
+    cfg.inference.sliding_window.window_size = [3, 3, 3]
+    cfg.inference.sliding_window.overlap = 0.5
+    cfg.inference.sliding_window.blending = "constant"
+    cfg.inference.sliding_window.snap_to_edge = True
+    cfg.inference.chunking.enabled = True
+    cfg.inference.chunking.output_mode = "raw_prediction"
+    cfg.inference.chunking.chunk_size = [2, 4, 7]
+    cfg.inference.chunking.halo = [0, 0, 0]
+    cfg.inference.save_compression = "none"
+
+    image_path = tmp_path / "external_shard_input.h5"
+    output_path = tmp_path / "external_shard_prediction.h5"
+    volume = np.arange(5 * 6 * 7, dtype=np.float32).reshape(5, 6, 7)
+    write_hdf5(str(image_path), volume, dataset="main")
+
+    full = lazy_predict_volume(cfg, _patch_mean_forward, str(image_path), device="cpu")
+    for shard_id in range(2):
+        cfg.inference.chunking.shard_id = shard_id
+        cfg.inference.chunking.num_shards = 2
+        assert is_external_chunk_sharding_enabled(cfg) is True
+        run_chunked_prediction_inference(
+            cfg,
+            _patch_mean_forward,
+            str(image_path),
+            output_path=output_path,
+            device="cpu",
+            checkpoint_path="checkpoint.ckpt",
+        )
+
+    assert not output_path.exists()
+    assert (tmp_path / "external_shard_prediction.h5.index.json").is_file()
+    chunks_dir = _per_chunk_dir(output_path)
+    chunk_files = sorted(chunks_dir.glob("chunk_*.h5"))
+    assert len(chunk_files) == len(
+        build_chunk_grid(volume.shape, tuple(cfg.inference.chunking.chunk_size))
+    )
+
+    stitch(output_path, slab=2)
+
+    import h5py
+
+    with h5py.File(output_path, "r") as handle:
+        raw = np.asarray(handle["main"])
+
+    assert raw.shape == tuple(full.shape[1:])
+    assert np.allclose(raw, full.numpy()[0], atol=1.0e-5)

--- a/tests/unit/test_data_factory.py
+++ b/tests/unit/test_data_factory.py
@@ -6,6 +6,7 @@ import pytest
 from monai.transforms import Compose, Resized
 
 from connectomics.config import Config
+from connectomics.config.pipeline.config_io import resolve_data_paths
 from connectomics.data.augmentation.build import build_test_transforms, build_val_transforms
 from connectomics.data.augmentation.transforms import ResizeByFactord
 from connectomics.training.lightning.data_factory import create_datamodule
@@ -83,6 +84,36 @@ def test_create_datamodule_test_lazy_profile_keeps_paths_unloaded(tmp_path):
     batch = next(iter(datamodule.test_dataloader()))
 
     assert batch["image"] == [str(image_path)]
+
+
+def test_resolve_data_paths_resolves_test_json(tmp_path):
+    cfg = Config()
+    cfg.data.test.path = str(tmp_path)
+    cfg.data.test.json = "tiles.json"
+
+    resolve_data_paths(cfg)
+
+    assert cfg.data.test.json == str(tmp_path / "tiles.json")
+
+
+def test_create_datamodule_test_tile_uses_json_as_lazy_image(tmp_path):
+    metadata_path = tmp_path / "im_align_10nm.json"
+
+    cfg = Config()
+    cfg.data.test.dataset_type = "tile"
+    cfg.data.test.json = str(metadata_path)
+    cfg.data.test.name = "im_align_10nm"
+    cfg.inference.strategy = "chunked"
+    cfg.inference.chunking.enabled = True
+    cfg.inference.chunking.output_mode = "raw_prediction"
+    cfg.system.num_workers = 0
+    cfg.data.dataloader.batch_size = 1
+
+    datamodule = create_datamodule(cfg, mode="test")
+    batch = next(iter(datamodule.test_dataloader()))
+
+    assert batch["image"] == [str(metadata_path)]
+    assert datamodule.distributed_chunked_raw_sharding is True
 
 
 def test_create_datamodule_chunked_raw_replicates_single_test_volume_without_window_sharding(

--- a/tests/unit/test_lazy_inference.py
+++ b/tests/unit/test_lazy_inference.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+import imageio.v2 as imageio
 import numpy as np
 import torch
 
@@ -8,10 +11,12 @@ from connectomics.data.augmentation.build import build_test_transforms
 from connectomics.data.io import write_hdf5
 from connectomics.inference import InferenceManager
 from connectomics.inference.lazy import (
+    LazyVolumeAccessor,
     _build_intersecting_window_slices,
     _build_window_slices,
     lazy_predict_region,
     lazy_predict_volume,
+    load_lazy_volume,
 )
 from connectomics.inference.window import build_sliding_importance_map
 
@@ -100,6 +105,56 @@ def test_lazy_model_output_dtype_controls_accumulators(tmp_path):
         torch.from_numpy(volume).unsqueeze(0).unsqueeze(0),
         atol=5.0e-4,
     )
+
+
+def test_lazy_tile_accessor_reads_cross_tile_patch_and_infers_missing_json(tmp_path):
+    volume = np.arange(2 * 4 * 6, dtype=np.uint8).reshape(2, 4, 6)
+    tile_root = tmp_path / "im_align_10nm"
+    for z in range(volume.shape[0]):
+        section_dir = tile_root / f"{z:04d}"
+        section_dir.mkdir(parents=True)
+        for row in range(2):
+            for col in range(2):
+                y0 = row * 2
+                x0 = col * 3
+                imageio.imwrite(
+                    section_dir / f"{row}_{col}.png", volume[z, y0 : y0 + 2, x0 : x0 + 3]
+                )
+
+    missing_json_path = tmp_path / "im_align_10nm.json"
+    with LazyVolumeAccessor(
+        str(missing_json_path),
+        kind="image",
+        normalize_mode="none",
+    ) as accessor:
+        patch = accessor.read_patch(
+            (0, 1, 2),
+            (2, 2, 3),
+            outer_pad_mode="constant",
+            outer_pad_value=0.0,
+        )
+
+    expected = volume[0:2, 1:3, 2:5].astype(np.float32)
+    assert patch.shape == (1, 2, 2, 3)
+    assert np.array_equal(patch[0], expected)
+
+    metadata_path = tmp_path / "explicit_tiles.json"
+    metadata = {
+        "image": [f"im_align_10nm/{z:04d}/{{row}}_{{column}}.png" for z in range(2)],
+        "depth": 2,
+        "height": 4,
+        "width": 6,
+        "tile_size": [2, 3],
+        "dtype": "uint8",
+        "tile_st": [0, 0],
+        "tile_ratio": 1.0,
+    }
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    cfg = _make_cfg()
+    loaded = load_lazy_volume(cfg, str(metadata_path), kind="image", mode="test")
+
+    assert np.array_equal(loaded, volume[np.newaxis].astype(np.float32))
 
 
 def test_lazy_region_matches_full_volume_global_window_grid(tmp_path):

--- a/tests/unit/test_main_runtime_stage_switch.py
+++ b/tests/unit/test_main_runtime_stage_switch.py
@@ -20,6 +20,7 @@ from connectomics.runtime.dispatch import dispatch_runtime
 from connectomics.runtime.sharding import (
     has_assigned_test_shard,
     maybe_enable_independent_test_sharding,
+    maybe_enable_naive_chunk_sharding,
     maybe_limit_test_devices,
     resolve_test_stage_runtime,
 )
@@ -250,6 +251,26 @@ def test_has_assigned_test_shard_returns_false_for_empty_slice(tmp_path, monkeyp
     )
 
     assert has_assigned_test_shard(cfg, args) is False
+
+
+def test_naive_chunk_sharding_claims_explicit_shard_args_without_volume_sharding(tmp_path):
+    args = _make_args(tmp_path / "config.yaml")
+    args.shard_id = 1
+    args.num_shards = 4
+    cfg = Config()
+    cfg.system.num_gpus = 8
+    cfg.inference.strategy = "chunked"
+    cfg.inference.chunking.enabled = True
+    cfg.inference.chunking.output_mode = "raw_prediction"
+
+    changed = maybe_enable_naive_chunk_sharding(args, cfg)
+
+    assert changed is True
+    assert cfg.inference.chunking.shard_id == 1
+    assert cfg.inference.chunking.num_shards == 4
+    assert cfg.system.num_gpus == (1 if torch.cuda.is_available() else 0)
+    assert maybe_enable_independent_test_sharding(args, cfg) is False
+    assert has_assigned_test_shard(cfg, args) is True
 
 
 def test_tune_cache_only_preserves_checkpoint_tag_for_tuning_suffix(tmp_path, monkeypatch):

--- a/tests/unit/test_malis_loss.py
+++ b/tests/unit/test_malis_loss.py
@@ -1,0 +1,447 @@
+"""Tests for MalisLoss wrapper around lib/malis."""
+
+from contextlib import contextmanager
+import unittest
+
+import numpy as np
+import torch
+
+try:
+    import malis as _malis_lib  # noqa: F401
+
+    _HAS_MALIS = True
+except Exception:
+    _HAS_MALIS = False
+
+
+def _reference_malis_pass(
+    pred_affs: np.ndarray,
+    gt_affs: np.ndarray,
+    gt_seg: np.ndarray,
+    nhood: np.ndarray,
+    mask: np.ndarray | None,
+    pos: int,
+) -> np.ndarray:
+    pass_affs = np.array(pred_affs, copy=True)
+    class_edges = gt_affs == (1 - pos)
+    if mask is None:
+        constraint_edges = class_edges
+    else:
+        mask_b = np.ascontiguousarray(mask == 1, dtype=bool)
+        constraint_edges = class_edges & mask_b
+    pass_affs[constraint_edges] = 1 - pos
+
+    node1, node2 = _malis_lib.nodelist_like(gt_seg.shape, nhood)
+    weights = _malis_lib.malis_loss_weights(
+        np.ascontiguousarray(gt_seg, dtype=np.uint64).ravel(),
+        np.ascontiguousarray(node1, dtype=np.uint64).ravel(),
+        np.ascontiguousarray(node2, dtype=np.uint64).ravel(),
+        np.ascontiguousarray(pass_affs, dtype=np.float32).ravel(),
+        pos,
+    )
+    weights = weights.reshape((-1,) + tuple(gt_seg.shape)).astype(np.float32, copy=False)
+    weights[class_edges] = 0.0
+    if mask is not None:
+        weights[~mask_b] = 0.0
+
+    num_pairs = weights.sum(dtype=np.float64)
+    if num_pairs > 0:
+        weights = weights / np.float32(num_pairs)
+    return weights
+
+
+def _reference_malis_weights(
+    pred_affs: np.ndarray,
+    target_affs: np.ndarray,
+    nhood: np.ndarray,
+    mask: np.ndarray | None = None,
+) -> np.ndarray:
+    gt_affs = np.ascontiguousarray(target_affs > 0.5, dtype=np.int32)
+    gt_seg, _ = _malis_lib.connected_components_affgraph(gt_affs, nhood)
+    weights_neg = _reference_malis_pass(pred_affs, gt_affs, gt_seg, nhood, mask, pos=0)
+    weights_pos = _reference_malis_pass(pred_affs, gt_affs, gt_seg, nhood, mask, pos=1)
+    return weights_neg + weights_pos
+
+
+def _reference_malis_loss(
+    pred_affs: np.ndarray,
+    target_affs: np.ndarray,
+    nhood: np.ndarray,
+    mask: np.ndarray | None = None,
+) -> np.float32:
+    weights = _reference_malis_weights(pred_affs, target_affs, nhood, mask)
+    sqerr = np.square((pred_affs - target_affs).astype(np.float32, copy=False))
+    return np.sum(weights * sqerr, dtype=np.float32)
+
+
+@contextmanager
+def _fixed_torch_randint(value: int):
+    original_randint = torch.randint
+
+    def _fake_randint(*args, **kwargs):
+        return torch.tensor([value], dtype=torch.long)
+
+    torch.randint = _fake_randint
+    try:
+        yield
+    finally:
+        torch.randint = original_randint
+
+
+@unittest.skipUnless(_HAS_MALIS, "malis extension not built")
+class TestMalisLoss(unittest.TestCase):
+    def _crop_loss_shape(self, crop_size):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(malis_crop_size=crop_size, reduction="none", sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.zeros(1, C, 8, 8, 8)
+        target = torch.zeros_like(pred)
+        loss_fn._compute_malis_weights = lambda pred_aff, target_aff, mask=None: torch.ones_like(
+            pred_aff
+        )
+        return loss_fn(pred, target).shape, loss_fn.malis_crop_size, C
+
+    def test_create_via_registry(self):
+        from connectomics.models.losses import create_loss
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = create_loss("MalisLoss")
+        meta = getattr(loss_fn, "_connectomics_loss_metadata", None)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.name, "MalisLoss")
+        self.assertEqual(meta.spatial_weight_arg, "mask")
+        self.assertIsInstance(loss_fn, MalisLoss)
+
+    def test_not_in_package_namespace(self):
+        """MalisLoss is intentionally not re-exported from the package __init__."""
+        import connectomics.models.losses as _pkg
+
+        self.assertFalse(hasattr(_pkg, "MalisLoss"))
+
+    def test_forward_simple_3d(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(0)
+        loss_fn = MalisLoss()
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        pred = torch.randn(1, C, 6, 8, 8, requires_grad=True)
+        gt_seg = np.zeros((6, 8, 8), dtype=np.int32)
+        gt_seg[:4, :, :] = 1
+        aff = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        target = torch.from_numpy(aff).unsqueeze(0)
+        loss = loss_fn(pred, target)
+        self.assertTrue(torch.isfinite(loss).item())
+        self.assertGreaterEqual(loss.item(), 0.0)
+        loss.backward()
+        self.assertTrue(torch.isfinite(pred.grad).all().item())
+
+    def test_loss_matches_numpy_reference_with_and_without_mask(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(sigmoid=False)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        pred_np = np.linspace(0.05, 0.95, num=C * 3 * 4 * 5, dtype=np.float32).reshape(
+            C,
+            3,
+            4,
+            5,
+        )
+        gt_seg = np.zeros((3, 4, 5), dtype=np.int32)
+        gt_seg[:, :2, :] = 1
+        gt_seg[:, 2:, :] = 2
+        target_np = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        mask_np = np.ones((1, 3, 4, 5), dtype=np.float32)
+        mask_np[:, :, 1:3, :] = 0.0
+
+        pred = torch.from_numpy(pred_np).unsqueeze(0)
+        target = torch.from_numpy(target_np).unsqueeze(0)
+        mask = torch.from_numpy(mask_np).unsqueeze(0)
+
+        expected_unmasked = _reference_malis_loss(pred_np, target_np, nhood)
+        expected_masked = _reference_malis_loss(
+            pred_np,
+            target_np,
+            nhood,
+            np.broadcast_to(mask_np, target_np.shape),
+        )
+
+        torch.testing.assert_close(
+            loss_fn(pred, target),
+            torch.tensor(expected_unmasked),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        torch.testing.assert_close(
+            loss_fn(pred, target, mask=mask),
+            torch.tensor(expected_masked),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+    def test_reduction_default_and_supported_modes(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        base_loss = MalisLoss(sigmoid=False)
+        C = base_loss.nhood.shape[0]
+        pred = torch.linspace(0.0, 0.9, steps=C * 2 * 2 * 2, dtype=torch.float32).reshape(
+            1,
+            C,
+            2,
+            2,
+            2,
+        )
+        target = torch.zeros_like(pred)
+        weights = torch.linspace(0.1, 1.0, steps=pred.numel(), dtype=torch.float32)
+        weights = weights.reshape_as(pred)
+        expected = weights * pred.square()
+
+        for reduction, expected_value in (
+            ("sum", expected.sum()),
+            ("mean", expected.mean()),
+            ("none", expected),
+        ):
+            if reduction == "sum":
+                loss_fn = base_loss
+            else:
+                loss_fn = MalisLoss(reduction=reduction, sigmoid=False)
+            loss_fn._compute_malis_weights = lambda pred_aff, target_aff, mask=None: weights
+            torch.testing.assert_close(loss_fn(pred, target), expected_value)
+
+    def test_mask_does_not_change_topology(self):
+        """Regression: mask must NOT influence the CC reconstruction.
+
+        Strategy: monkey-patch malis.connected_components_affgraph to record
+        the int32 affinity array it is called with, then run forward() once
+        without mask and once with a topology-splitting mask. Both calls must
+        receive an identical CC input (i.e. mask is not folded in before CC).
+        """
+        from connectomics.models.losses import malis as malis_mod
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(0)
+        loss_fn = MalisLoss()
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+
+        gt_seg = np.zeros((6, 8, 8), dtype=np.int32)
+        gt_seg[:4, :, :] = 1
+        aff = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        target = torch.from_numpy(aff).unsqueeze(0)
+        pred = torch.randn(1, C, 6, 8, 8)
+
+        recorded: list[np.ndarray] = []
+        real_cc = _malis_lib.connected_components_affgraph
+
+        def _spy(aff_in, nh_in):
+            recorded.append(np.array(aff_in, copy=True))
+            return real_cc(aff_in, nh_in)
+
+        # Patch at the lookup site used inside malis.py (it references the
+        # module-level `_malis_lib`).
+        orig = malis_mod._malis_lib.connected_components_affgraph
+        malis_mod._malis_lib.connected_components_affgraph = _spy
+        try:
+            _ = loss_fn(pred, target)
+            mask = torch.ones(1, 1, 6, 8, 8)
+            mask[:, :, 1:3, :, :] = 0
+            _ = loss_fn(pred, target, mask=mask)
+        finally:
+            malis_mod._malis_lib.connected_components_affgraph = orig
+
+        self.assertEqual(len(recorded), 2)
+        # The CC INPUT array must be identical between the two calls:
+        # mask must not be folded in before CC.
+        np.testing.assert_array_equal(recorded[0], recorded[1])
+
+    def test_malis_crop_size_int_shape(self):
+        shape, crop_size, C = self._crop_loss_shape(4)
+
+        self.assertEqual(shape, (1, C, 4, 4, 4))
+        self.assertEqual(crop_size, (4, 4, 4))
+
+    def test_malis_crop_size_tuple_shape(self):
+        shape, crop_size, C = self._crop_loss_shape((2, 4, 4))
+
+        self.assertEqual(shape, (1, C, 2, 4, 4))
+        self.assertEqual(crop_size, (2, 4, 4))
+
+    def test_malis_crop_size_list_shape(self):
+        shape, crop_size, C = self._crop_loss_shape([2, 4, 4])
+
+        self.assertEqual(shape, (1, C, 2, 4, 4))
+        self.assertEqual(crop_size, (2, 4, 4))
+
+    def test_malis_crop_size_omegaconf_list_shape(self):
+        try:
+            from omegaconf import OmegaConf
+        except Exception as e:
+            self.skipTest(f"omegaconf not importable: {e}")
+
+        shape, crop_size, C = self._crop_loss_shape(OmegaConf.create([2, 4, 4]))
+
+        self.assertEqual(shape, (1, C, 2, 4, 4))
+        self.assertEqual(crop_size, (2, 4, 4))
+
+    def test_malis_crop_size_none_preserves_shape(self):
+        shape, crop_size, C = self._crop_loss_shape(None)
+
+        self.assertEqual(shape, (1, C, 8, 8, 8))
+        self.assertIsNone(crop_size)
+
+    def test_malis_crop_size_gradient_flows_with_fixed_origin(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(malis_crop_size=4, sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.ones(1, C, 8, 8, 8, requires_grad=True)
+        target = torch.zeros_like(pred)
+        loss_fn._compute_malis_weights = lambda pred_aff, target_aff, mask=None: torch.ones_like(
+            pred_aff
+        )
+
+        with _fixed_torch_randint(2):
+            loss = loss_fn(pred, target)
+        loss.backward()
+
+        grad = pred.grad
+        self.assertIsNotNone(grad)
+        self.assertEqual(grad[..., :2, :, :].abs().sum().item(), 0.0)
+        self.assertEqual(grad[..., 6:, :, :].abs().sum().item(), 0.0)
+        self.assertEqual(grad[..., :, :2, :].abs().sum().item(), 0.0)
+        self.assertEqual(grad[..., :, 6:, :].abs().sum().item(), 0.0)
+        self.assertEqual(grad[..., :, :, :2].abs().sum().item(), 0.0)
+        self.assertEqual(grad[..., :, :, 6:].abs().sum().item(), 0.0)
+        self.assertGreater(grad[..., 2:6, 2:6, 2:6].abs().sum().item(), 0.0)
+
+    def test_malis_crop_size_validation_construction(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        for bad_value in (0, -1, (2, 4), (2, 4, 5, 6), "foo", (2, 0, 4)):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaises(ValueError):
+                    MalisLoss(malis_crop_size=bad_value)
+        for bad_value in (1.5, True, (True, 4, 4), [1.5, 2, 3]):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaises(ValueError):
+                    MalisLoss(malis_crop_size=bad_value)
+
+    def test_malis_crop_size_too_large_at_forward(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(malis_crop_size=99, sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.zeros(1, C, 4, 4, 4)
+        target = torch.zeros_like(pred)
+
+        with self.assertRaises(ValueError):
+            loss_fn(pred, target)
+
+    def test_malis_crop_does_not_break_mask_topology(self):
+        from connectomics.models.losses import malis as malis_mod
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(0)
+        loss_fn = MalisLoss(malis_crop_size=4)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+
+        gt_seg = np.zeros((8, 8, 8), dtype=np.int32)
+        gt_seg[:4, :, :] = 1
+        aff = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        target = torch.from_numpy(aff).unsqueeze(0)
+        pred = torch.randn(1, C, 8, 8, 8)
+
+        recorded: list[np.ndarray] = []
+        real_cc = _malis_lib.connected_components_affgraph
+
+        def _spy(aff_in, nh_in):
+            recorded.append(np.array(aff_in, copy=True))
+            return real_cc(aff_in, nh_in)
+
+        orig_cc = malis_mod._malis_lib.connected_components_affgraph
+        malis_mod._malis_lib.connected_components_affgraph = _spy
+        try:
+            with _fixed_torch_randint(2):
+                _ = loss_fn(pred, target)
+                mask = torch.ones(1, 1, 8, 8, 8)
+                mask[:, :, 2:4, :, :] = 0
+                _ = loss_fn(pred, target, mask=mask)
+        finally:
+            malis_mod._malis_lib.connected_components_affgraph = orig_cc
+
+        self.assertEqual(len(recorded), 2)
+        np.testing.assert_array_equal(recorded[0], recorded[1])
+
+    def test_malis_crop_edge_list_cache_hit(self):
+        from connectomics.models.losses import malis as malis_mod
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(malis_crop_size=4, sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.rand(1, C, 8, 8, 8)
+        target = torch.zeros_like(pred)
+
+        call_count = 0
+        real_nodelist_like = _malis_lib.nodelist_like
+
+        def _spy(shape, nhood):
+            nonlocal call_count
+            call_count += 1
+            return real_nodelist_like(shape, nhood)
+
+        orig = malis_mod._malis_lib.nodelist_like
+        malis_mod._malis_lib.nodelist_like = _spy
+        try:
+            _ = loss_fn(pred, target)
+            _ = loss_fn(pred, target)
+        finally:
+            malis_mod._malis_lib.nodelist_like = orig
+
+        self.assertEqual(call_count, 1)
+
+    def test_malis_crop_contiguous_output_path(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(0)
+        loss_fn = MalisLoss(malis_crop_size=4, sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.rand(1, C, 8, 8, 8, dtype=torch.float32)
+        target = torch.zeros_like(pred)
+
+        loss = loss_fn(pred, target)
+
+        self.assertTrue(torch.isfinite(loss).item())
+
+    def test_shape_mismatch_raises(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss()
+        pred = torch.randn(1, loss_fn.nhood.shape[0], 4, 4, 4)
+        target = torch.zeros(1, loss_fn.nhood.shape[0], 4, 4, 5)
+        with self.assertRaises(ValueError):
+            loss_fn(pred, target)
+
+    def test_2d_not_supported(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss()
+        pred = torch.randn(1, loss_fn.nhood.shape[0], 4, 4)
+        target = torch.zeros_like(pred)
+        with self.assertRaises(NotImplementedError):
+            loss_fn(pred, target)
+
+
+class TestMalisLossImportFallback(unittest.TestCase):
+    @unittest.skipIf(_HAS_MALIS, "malis is available; cannot test ImportError path")
+    def test_import_error_when_extension_missing(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        with self.assertRaises(ImportError):
+            MalisLoss()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutorials/neuron_nisb/base_banis+_malis.yaml
+++ b/tutorials/neuron_nisb/base_banis+_malis.yaml
@@ -30,3 +30,4 @@ default:
             nhood: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
             sigmoid: true
             reduction: mean
+            # malis_crop_size: 64  # symmetric; or e.g. [32, 64, 64] for asymmetric. See lib/malis/INVESTIGATION.md.

--- a/tutorials/neuron_nisb/base_banis+_zebrafinch.yaml
+++ b/tutorials/neuron_nisb/base_banis+_zebrafinch.yaml
@@ -1,0 +1,115 @@
+_base_:
+  - base_banis+.yaml
+
+experiment_name: nisb_base_banis+_zebrafinch
+description: >-
+  Apply the base_banis+ MedNeXt-L/k3 affinity model (trained on NISB at 9nm)
+  to the zebrafinch im_align_10nm tiled PNG volume via chunked inference.
+  Source layout: 5700 z-sections (0000..5699), each section is a 3x3 grid of
+  4096x4096 PNG tiles named {row}_{column}.png (uint8, mode L). Effective
+  full volume is 5700 x 12288 x 12288 (ZYX).
+
+save_path: outputs/nisb_base_banis+_zebrafinch
+
+default:
+  inference:
+    model:
+      # Keep only short-range affinities (axis0, axis1, axis2 in XYZ order).
+      select_channel: [0, 1, 2]
+      output_dtype: float16
+      channel_activations:
+        - {channels: ":", activation: scale_sigmoid}
+    execution:
+      strategy: chunked
+    window:
+      distributed_sharding: false
+      distributed_reduce_chunk_mb: 128
+      keep_input_on_cpu: true
+      sw_device: cuda
+      output_device: cpu
+      # 144 = 128 (training patch) + 16 voxels of context. Default bump blending
+      # de-emphasizes the outer band. Must remain a multiple of MedNeXt's
+      # 16-voxel stride.
+      window_size: [144, 144, 144]
+      sw_batch_size: 2
+      overlap: 0.5
+      blending: bump
+      padding_mode: replicate
+      # BANIS-style boundary handling: snap last window to image_size-roi_size.
+      snap_to_edge: true
+    chunking:
+      enabled: true
+      # raw_prediction parallelizes chunks across DDP ranks (idx % world_size).
+      output_mode: raw_prediction
+      # window stride = 144 * (1 - 0.5) = 72. Internal chunk starts must be
+      # multiples of 72; 1008 = 14 * 72. For 5700 x 12288 x 12288 this gives
+      # roughly 6 x 13 x 13 = ~1014 chunks; the last chunk along each axis is
+      # smaller because the full extent is not divisible by 1008.
+      chunk_size: [1008, 1008, 1008]
+      halo: [0, 0, 0]
+      axes: all
+    save_results: true
+    save_backend: h5
+    save_dtype: float16
+    test_time_augmentation:
+      enabled: false
+
+  decoding:
+    enabled: true
+    # Tag participates in decoded-output filenames so chunked variants do not
+    # collide with prior runs.
+    save_suffix: zebrafinch_chunk_raw_grid1008_halo0
+    # Empty string = no affinity QC mask (the inherited base_banis path is
+    # NISB-specific and does not apply to zebrafinch).
+    affinity_mask_path: ""
+    steps:
+      - name: decode_affinity_cc
+        kwargs:
+          threshold: 0.75
+          backend: numba
+          edge_offset: 0
+
+  evaluation:
+    enabled: false
+
+test:
+  system:
+    # raw_prediction chunking parallelizes across ranks.
+    num_gpus: -1
+  decoding:
+    # Override the NISB-specific QC mask inherited from base_banis' test stage;
+    # it does not apply to zebrafinch. Empty string = no affinity mask.
+    affinity_mask_path: ""
+  data:
+    test:
+      # Tile-reader input for the zebrafinch im_align_10nm PNG pyramid.
+      # Source layout under /projects/weilab/dataset/zebrafinch/im_align_10nm/
+      #   <section:04d>/{row}_{column}.png  with row,column in 0..2 and
+      #   tile_size = [4096, 4096], dtype = uint8 (mode L). Effective volume
+      #   shape (ZYX) = 5700 x 12288 x 12288.
+      #
+      # Canonical tile metadata (consumed by TileLoaderd in
+      # connectomics/data/io/transforms.py) lives in im_align_10nm.json with
+      # the shape:
+      #   {
+      #     "image": ["im_align_10nm/0000/{row}_{column}.png", ...,
+      #               "im_align_10nm/5699/{row}_{column}.png"],
+      #     "depth": 5700, "height": 12288, "width": 12288,
+      #     "tile_size": [4096, 4096],
+      #     "dtype": "uint8",
+      #     "tile_st": [0, 0],
+      #     "tile_ratio": 1.0
+      #   }
+      #
+      # NOTE on wiring: the framework already ships the tile primitives
+      # (connectomics/data/io/tiles.py::reconstruct_volume_from_tiles and the
+      # TileLoaderd MONAI transform), but the chunked-inference path uses
+      # LazyVolumeAccessor (connectomics/inference/lazy.py), which currently
+      # only opens h5/zarr/tiff. To run this config end-to-end you either
+      # (a) extend LazyVolumeAccessor with a tile/JSON backend that reads the
+      # JSON above and stitches PNG tiles on demand, or (b) pre-stitch the
+      # tiles into a single h5/zarr volume and point image: at it.
+      dataset_type: tile
+      path: /projects/weilab/dataset/zebrafinch
+      json: im_align_10nm.json
+      resolution: [10, 10, 10]

--- a/tutorials/neuron_nisb/base_banis+_zebrafinch.yaml
+++ b/tutorials/neuron_nisb/base_banis+_zebrafinch.yaml
@@ -31,7 +31,13 @@ default:
       # de-emphasizes the outer band. Must remain a multiple of MedNeXt's
       # 16-voxel stride.
       window_size: [144, 144, 144]
-      sw_batch_size: 2
+      # Test shards run 1 GPU each on 49 GB L40S. Measured peak GPU memory is
+      # linear in sw_batch_size (~3.46 GB/unit + ~0.77 GB fixed, with
+      # expandable_segments): batch 2 -> 7.7 GB, batch 8 -> 28.5 GB. 12 targets
+      # ~42 GB (~86%, ~7 GB headroom) to maximize GPU use without OOM; 13 (~46 GB)
+      # is the hard ceiling and 14 (~49 GB) OOMs on a 49 GB card. (Zarr reads keep
+      # the GPU fed; on PNG tiles it sat at 0% regardless of batch.)
+      sw_batch_size: 12
       overlap: 0.5
       blending: bump
       padding_mode: replicate
@@ -39,14 +45,16 @@ default:
       snap_to_edge: true
     chunking:
       enabled: true
-      # raw_prediction parallelizes chunks across DDP ranks (idx % world_size).
+      # raw_prediction lets independent sbatch jobs split chunks by
+      # --shard-id/--num-shards without torch.distributed.
       output_mode: raw_prediction
       # window stride = 144 * (1 - 0.5) = 72. Internal chunk starts must be
       # multiples of 72; 1008 = 14 * 72. For 5700 x 12288 x 12288 this gives
       # roughly 6 x 13 x 13 = ~1014 chunks; the last chunk along each axis is
       # smaller because the full extent is not divisible by 1008.
       chunk_size: [1008, 1008, 1008]
-      halo: [0, 0, 0]
+      # Each chunk job reads an overlapping halo and writes only its core.
+      halo: [72, 72, 72]
       axes: all
     save_results: true
     save_backend: h5
@@ -58,14 +66,17 @@ default:
     enabled: true
     # Tag participates in decoded-output filenames so chunked variants do not
     # collide with prior runs.
-    save_suffix: zebrafinch_chunk_raw_grid1008_halo0
+    save_suffix: zebrafinch_chunk_raw_grid1008_halo72
     # Empty string = no affinity QC mask (the inherited base_banis path is
     # NISB-specific and does not apply to zebrafinch).
     affinity_mask_path: ""
     steps:
       - name: decode_affinity_cc
         kwargs:
-          threshold: 0.75
+          # Best NISB BANIS+ validation setting used for the reference run:
+          # just test neuron_nisb/base_banis+_zebrafinch \
+          #   outputs/nisb_base_banis_v3_erosion2/20260508_224029/checkpoints/step=00200000.ckpt
+          threshold: 0.66
           backend: numba
           edge_offset: 0
 
@@ -74,8 +85,8 @@ default:
 
 test:
   system:
-    # raw_prediction chunking parallelizes across ranks.
-    num_gpus: -1
+    # Each sbatch shard is an independent one-GPU job; do not use DDP.
+    num_gpus: 1
   decoding:
     # Override the NISB-specific QC mask inherited from base_banis' test stage;
     # it does not apply to zebrafinch. Empty string = no affinity mask.
@@ -88,9 +99,7 @@ test:
       #   tile_size = [4096, 4096], dtype = uint8 (mode L). Effective volume
       #   shape (ZYX) = 5700 x 12288 x 12288.
       #
-      # Canonical tile metadata (consumed by TileLoaderd in
-      # connectomics/data/io/transforms.py) lives in im_align_10nm.json with
-      # the shape:
+      # Tile metadata can be supplied as im_align_10nm.json with the shape:
       #   {
       #     "image": ["im_align_10nm/0000/{row}_{column}.png", ...,
       #               "im_align_10nm/5699/{row}_{column}.png"],
@@ -100,16 +109,16 @@ test:
       #     "tile_st": [0, 0],
       #     "tile_ratio": 1.0
       #   }
-      #
-      # NOTE on wiring: the framework already ships the tile primitives
-      # (connectomics/data/io/tiles.py::reconstruct_volume_from_tiles and the
-      # TileLoaderd MONAI transform), but the chunked-inference path uses
-      # LazyVolumeAccessor (connectomics/inference/lazy.py), which currently
-      # only opens h5/zarr/tiff. To run this config end-to-end you either
-      # (a) extend LazyVolumeAccessor with a tile/JSON backend that reads the
-      # JSON above and stitches PNG tiles on demand, or (b) pre-stitch the
-      # tiles into a single h5/zarr volume and point image: at it.
+      # If the JSON is absent, the lazy tile reader infers the same metadata
+      # from the sibling im_align_10nm/ section directory.
       dataset_type: tile
       path: /projects/weilab/dataset/zebrafinch
+      # Clear the inherited NISB zarr/label/skeleton paths from base_banis.yaml.
+      image: null
+      label: null
+      label_aux: null
+      mask: null
+      skeleton: null
       json: im_align_10nm.json
+      name: im_align_10nm
       resolution: [10, 10, 10]

--- a/tutorials/neuron_nisb/base_banis+_zebrafinch_zarr.yaml
+++ b/tutorials/neuron_nisb/base_banis+_zebrafinch_zarr.yaml
@@ -1,0 +1,26 @@
+_base_:
+  - base_banis+_zebrafinch.yaml
+
+experiment_name: nisb_base_banis+_zebrafinch_zarr
+description: >-
+  Same chunked affinity inference as base_banis+_zebrafinch.yaml, but reading
+  the volume from the converted multiscale OME-Zarr
+  (im_align_10nm.zarr, level 0 = full 10nm resolution) instead of the tiled PNG
+  pyramid. Zarr is random-access and compressed in 128^3 blocks, so the lazy
+  sliding-window reader no longer re-decodes 4096x4096 PNG tiles per ROI window
+  (the PNG path took ~19 h/chunk at 0% GPU). All window/chunking/decoding
+  settings are inherited unchanged so outputs are directly comparable.
+
+save_path: outputs/nisb_base_banis+_zebrafinch_zarr
+
+test:
+  data:
+    test:
+      # Switch from the tiled-PNG reader to the dense zarr volume. dataset_type
+      # null = generic volume; the .zarr suffix selects the zarr backend. The
+      # "/0" subkey is the full-resolution level of the multiscale group.
+      dataset_type: null
+      image: /projects/weilab/dataset/zebrafinch/im_align_10nm.zarr/0
+      # The inherited tile-only `path`/`json` are ignored once dataset_type is
+      # null (volume backend keys off `image`); leaving them avoids null-typing
+      # errors on those str fields.


### PR DESCRIPTION
## What

Lands the chunked/lazy sliding-window inference feature plus the zebrafinch tiled-PNG → OME-Zarr conversion pipeline.

### Inference feature
- `inference/lazy` + `inference/chunked`: lazy ROI-by-ROI sliding window + chunked raw-prediction output.
- `runtime/sharding` + `dispatch`: naive chunk-grid sharding via `--shard-id/--num-shards` for single-volume raw inference.
- `runtime/cache_resolver`: **skip the whole-volume cache-only path for chunked-raw inference**. That path shards by *volume*, so on a single-volume input it stranded all but shard 0 ("empty, nothing to do") — only 78/1014 chunks would have run. Guarded with `is_chunked_raw_inference(cfg)`.
- `config/schema/inference`, `data_factory`, `test_pipeline`, + unit tests.

### zebrafinch zarr
- `data/io/tiles`: parallel z-section decode in `reconstruct_volume_from_tiles` (`num_workers`); threads write disjoint `result[z]` planes (PNG decode releases the GIL). Verified byte-identical to the serial path.
- `inference/lazy`: thread `tile_read_workers` (from `cfg.system.num_workers`) into chunked tile reads.
- `scripts/tiles_to_zarr.py`: tiled-PNG → multiscale OME-Zarr converter — stages `init → base → pyramid → verify → remove-png` (deletion gated behind full verification + `--yes`); shardable for `just slurm-sharded`.
- `tutorials/neuron_nisb/base_banis+_zebrafinch_zarr.yaml`: reads zarr level 0 instead of PNG tiles.
- `base_banis+_zebrafinch.yaml`: `sw_batch_size` 2 → 12 (measured peak-memory model in the comment).

## Why

Lazy sliding-window inference on the tiled PNGs re-decoded full 4096² tiles per ROI window (~2,700 windows/chunk) → ~19 h/chunk at 0% GPU, effectively never finishing. Reading the chunked/compressed zarr makes it GPU-bound (~14.5 min/chunk, GPU ~100%).

## Testing
- `tests/unit/test_lazy_inference.py` + `test_chunked_inference.py`: 19 passed.
- Converter: full `init→base→pyramid→verify→remove-png` exercised on a synthetic tiled dataset (parallel == serial == ground truth; deletion gated correctly).
- Real run: zebrafinch zarr conversion verified byte-for-byte vs PNGs (10 shards, 0 mismatches); 13-shard inference confirmed all chunks covered (13×78=1014) and GPU ~100%.

## Review focus
- `runtime/cache_resolver` guard interaction with `dispatch`/`sharding` for the single-volume chunked-raw path.
- `reconstruct_volume_from_tiles` threading (disjoint-plane write safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)