### PR TITLE
MalisLoss: pass eroded gt_seg through data pipeline (skip per-step CC, fix crop topology)

### DIFF
--- a/connectomics/config/pipeline/config_io.py
+++ b/connectomics/config/pipeline/config_io.py
@@ -153,8 +153,7 @@ _MONITOR_CHECKPOINT_RENAMES = {
         "(sibling of `monitor`, `inference`, `decoding`, `tune`)."
     ),
     "use_timestamp": (
-        "field removed. Train mode is always timestamped; "
-        "test/tune modes are never timestamped."
+        "field removed. Train mode is always timestamped; " "test/tune modes are never timestamped."
     ),
 }
 _MONITOR_CHECKPOINT_ROOTS = (
@@ -201,8 +200,7 @@ def _reject_inference_runtime_alias_paths(explicit_field_paths: set[str]) -> Non
             alias_path = f"{root}.{alias}"
             if any(_path_is_or_descendant(path, alias_path) for path in explicit_field_paths):
                 raise ValueError(
-                    f"`{alias_path}` was renamed. "
-                    f"Use `{root}.{canonical_tail}` instead."
+                    f"`{alias_path}` was renamed. " f"Use `{root}.{canonical_tail}` instead."
                 )
 
     for root in _MONITOR_CHECKPOINT_ROOTS:
@@ -212,8 +210,7 @@ def _reject_inference_runtime_alias_paths(explicit_field_paths: set[str]) -> Non
                 if replacement.startswith("field "):
                     raise ValueError(f"`{alias_path}` {replacement}")
                 raise ValueError(
-                    f"`{alias_path}` was renamed. "
-                    f"Use `{root}.{replacement}` instead."
+                    f"`{alias_path}` was renamed. " f"Use `{root}.{replacement}` instead."
                 )
 
     # tune.output:* sub-block hoisted to tune.save_*
@@ -506,7 +503,6 @@ def validate_config(cfg: Config) -> None:
     if cfg.model.out_channels <= 0:
         raise ValueError("model.out_channels must be positive")
     model_heads = getattr(cfg.model, "heads", None) or {}
-    inference_cfg = getattr(cfg, "inference", None)
     inference_head = get_inference_model_value(cfg, "head", None)
     images_cfg = getattr(getattr(getattr(cfg, "monitor", None), "logging", None), "images", None)
     visualization_head = getattr(images_cfg, "head", None) if images_cfg is not None else None
@@ -556,8 +552,8 @@ def validate_config(cfg: Config) -> None:
             missing = [h for h in inference_head_names if h not in model_heads]
             if missing:
                 raise ValueError(
-                    f"inference.model.head={inference_head_names} references unknown heads {missing}; "
-                    f"available: {sorted(model_heads.keys())}."
+                    f"inference.model.head={inference_head_names} references unknown heads "
+                    f"{missing}; available: {sorted(model_heads.keys())}."
                 )
         if (
             visualization_head is not None
@@ -909,6 +905,11 @@ def resolve_data_paths(cfg: Config) -> Config:
         split_cfg.image = _combine_path(split_base, split_cfg.image)
         split_cfg.label = _combine_path(split_base, split_cfg.label)
         split_cfg.mask = _combine_path(split_base, split_cfg.mask)
+        split_json_resolved = _combine_path(split_base, split_cfg.json)
+        if isinstance(split_json_resolved, list):
+            split_cfg.json = split_json_resolved[0] if split_json_resolved else None
+        else:
+            split_cfg.json = split_json_resolved
 
     # Resolve inference/test paths from merged runtime cfg.data.
     if getattr(cfg.data, "test", None) is not None:

--- a/connectomics/config/schema/data.py
+++ b/connectomics/config/schema/data.py
@@ -66,6 +66,7 @@ class LabelTransformConfig:
 
     normalize: bool = True  # Convert labels to 0-1 range
     erosion: int = 0  # Border erosion kernel half-size (0 = disabled, uses seg_widen_border)
+    emit_gt_seg: bool = False  # Emit post-augmentation/post-erosion segmentation for MALIS.
     skeleton_distance: SkeletonDistanceConfig = field(default_factory=SkeletonDistanceConfig)
     edge_mode: EdgeModeConfig = field(
         default_factory=EdgeModeConfig

--- a/connectomics/data/augmentation/build.py
+++ b/connectomics/data/augmentation/build.py
@@ -183,7 +183,7 @@ def _build_nnunet_preprocess_transform(keys, nnunet_pre_cfg, source_spacing):
 
 
 def build_train_transforms(
-    cfg: Config, keys: list[str] = None, skip_loading: bool = False
+    cfg: Config, keys: list[str] | None = None, skip_loading: bool = False
 ) -> Compose:
     """
     Build training transforms from Hydra config.
@@ -351,7 +351,7 @@ def build_train_transforms(
 
 
 def _build_eval_transforms_impl(
-    cfg: Config, mode: str = "val", keys: list[str] = None, skip_loading: bool = False
+    cfg: Config, mode: str = "val", keys: list[str] | None = None, skip_loading: bool = False
 ) -> Compose:
     """
     Internal implementation for building evaluation transforms (validation or test).
@@ -700,7 +700,7 @@ def _build_eval_transforms_impl(
 
 
 def build_val_transforms(
-    cfg: Config, keys: list[str] = None, skip_loading: bool = False
+    cfg: Config, keys: list[str] | None = None, skip_loading: bool = False
 ) -> Compose:
     """
     Build validation transforms from Hydra config.
@@ -716,7 +716,9 @@ def build_val_transforms(
     return _build_eval_transforms_impl(cfg, mode="val", keys=keys, skip_loading=skip_loading)
 
 
-def build_test_transforms(cfg: Config, keys: list[str] = None, mode: str = "test") -> Compose:
+def build_test_transforms(
+    cfg: Config, keys: list[str] | None = None, mode: str = "test"
+) -> Compose:
     """
     Build test/tune inference transforms from Hydra config.
 

--- a/connectomics/data/augmentation/build.py
+++ b/connectomics/data/augmentation/build.py
@@ -15,6 +15,7 @@ from monai.transforms import (
     BorderPadd,
     CenterSpatialCropd,
     Compose,
+    CopyItemsd,
     Lambdad,
     OneOf,
     RandAdjustContrastd,
@@ -320,6 +321,8 @@ def build_train_transforms(
         # Apply instance erosion first if specified
         if hasattr(label_cfg, "erosion") and label_cfg.erosion > 0:
             transforms.append(SegErosionInstanced(keys=["label"], tsz_h=label_cfg.erosion))
+        if label_cfg.emit_gt_seg:
+            transforms.append(CopyItemsd(keys="label", names="gt_seg"))
 
         # Build label transform pipeline directly from label_transform config
         label_transform = create_label_transform_pipeline(label_cfg)
@@ -669,6 +672,8 @@ def _build_eval_transforms_impl(
             # Apply instance erosion first if specified
             if hasattr(label_cfg, "erosion") and label_cfg.erosion > 0:
                 transforms.append(SegErosionInstanced(keys=["label"], tsz_h=label_cfg.erosion))
+            if label_cfg.emit_gt_seg:
+                transforms.append(CopyItemsd(keys="label", names="gt_seg"))
 
             # Build label transform pipeline directly from label_transform config
             label_transform = create_label_transform_pipeline(label_cfg)

--- a/connectomics/models/losses/malis.py
+++ b/connectomics/models/losses/malis.py
@@ -26,6 +26,16 @@ class MalisLoss(nn.Module):
     2D tensors are rejected explicitly because the vendored MALIS helpers operate
     on 3D affinity graphs by default. See ``lib/malis/INVESTIGATION.md`` for
     GPU MALIS candidates and algorithm-level speedup follow-ups.
+
+    Performance knobs (see ``docs/source/notes/malis.rst``):
+
+    - ``malis_crop_size`` — random sub-volume crop on each forward call.
+      ``64`` on a ``128^3`` patch gives ~4.6x measured step speedup vs
+      the full-volume baseline (slurm 2505814 vs 2487040).
+    - ``label_transform.emit_gt_seg: true`` (YAML, paired with this
+      loss) — passes the eroded GT segmentation in via ``gt_seg=...``,
+      skipping the per-step ``connected_components_affgraph`` call and
+      preserving global instance IDs when ``malis_crop_size`` is set.
     """
 
     def __init__(
@@ -68,6 +78,7 @@ class MalisLoss(nn.Module):
         pred: torch.Tensor,
         target: torch.Tensor,
         mask: torch.Tensor | None = None,
+        gt_seg: torch.Tensor | np.ndarray | None = None,
     ) -> torch.Tensor:
         """Compute MALIS-weighted squared affinity error.
 
@@ -83,21 +94,31 @@ class MalisLoss(nn.Module):
                 Masked-out edges are excluded from MALIS pass constraints and
                 zeroed before per-pass normalization, but the mask does not
                 change GT connected-component reconstruction.
+            gt_seg: Optional ground-truth segmentation with shape ``[B, Z, Y, X]``
+                or ``[B, 1, Z, Y, X]``. When supplied, MALIS uses these instance
+                labels directly instead of reconstructing components from
+                ``target`` affinities.
         """
         self._validate_inputs(pred, target)
 
         pred_aff = torch.sigmoid(pred) if self.sigmoid else pred
         target_aff = target.to(device=pred.device, dtype=pred_aff.dtype)
         mask_aff = None if mask is None else self._prepare_mask(mask, pred_aff)
-        pred_aff, target_aff, mask_aff = self._apply_crop_if_configured(
+        gt_seg_tensor = self._prepare_gt_seg(gt_seg, pred_aff)
+        pred_aff, target_aff, mask_aff, gt_seg_tensor = self._apply_crop_if_configured(
             pred_aff,
             target_aff,
             mask_aff,
+            gt_seg_tensor,
         )
+        weight_kwargs = {}
+        if gt_seg_tensor is not None:
+            weight_kwargs["gt_seg"] = gt_seg_tensor.detach()
         weights = self._compute_malis_weights(
             pred_aff.detach(),
             target_aff.detach(),
             None if mask_aff is None else mask_aff.detach(),
+            **weight_kwargs,
         )
 
         edge_loss = (pred_aff - target_aff) ** 2
@@ -211,12 +232,36 @@ class MalisLoss(nn.Module):
                 f"mask={tuple(mask.shape)}, pred={tuple(pred.shape)}."
             ) from e
 
+    def _prepare_gt_seg(
+        self,
+        gt_seg: torch.Tensor | np.ndarray | None,
+        pred: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if gt_seg is None:
+            return None
+
+        gt_seg_tensor = torch.as_tensor(gt_seg, device=pred.device).detach()
+        if gt_seg_tensor.ndim == pred.ndim and gt_seg_tensor.shape[1] == 1:
+            gt_seg_tensor = gt_seg_tensor.squeeze(1)
+        elif gt_seg_tensor.ndim == pred.ndim - 2 and pred.shape[0] == 1:
+            gt_seg_tensor = gt_seg_tensor.unsqueeze(0)
+
+        expected_shape = (pred.shape[0],) + tuple(pred.shape[-3:])
+        if tuple(gt_seg_tensor.shape) != expected_shape:
+            raise ValueError(
+                "MalisLoss gt_seg must have shape [B, Z, Y, X] or [B, 1, Z, Y, X] "
+                f"matching pred spatial dims; got gt_seg={tuple(gt_seg_tensor.shape)}, "
+                f"expected={expected_shape}."
+            )
+        return gt_seg_tensor.contiguous()
+
     def _apply_crop_if_configured(
         self,
         pred_aff: torch.Tensor,
         target_aff: torch.Tensor,
         mask_aff: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        gt_seg: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """Apply the configured random sub-volume crop, if any.
 
         Offset sampling stays on CPU. The returned tensors are contiguous copies
@@ -226,11 +271,11 @@ class MalisLoss(nn.Module):
         crop=64, and fp16, pred + target + mask copies are about 9 MiB before
         overhead.
 
-        Returns ``(pred_cropped, target_cropped, mask_cropped)``. If no crop is
-        configured the inputs are returned unchanged.
+        Returns ``(pred_cropped, target_cropped, mask_cropped, gt_seg_cropped)``.
+        If no crop is configured the inputs are returned unchanged.
         """
         if self.malis_crop_size is None:
-            return pred_aff, target_aff, mask_aff
+            return pred_aff, target_aff, mask_aff, gt_seg
 
         k_z, k_y, k_x = self.malis_crop_size
         z_dim, y_dim, x_dim = pred_aff.shape[-3:]
@@ -253,17 +298,25 @@ class MalisLoss(nn.Module):
             if mask_aff is None
             else mask_aff.narrow(-3, z0, k_z).narrow(-2, y0, k_y).narrow(-1, x0, k_x).contiguous()
         )
-        return pred_c, target_c, mask_c
+        gt_seg_c = (
+            None
+            if gt_seg is None
+            else gt_seg.narrow(-3, z0, k_z).narrow(-2, y0, k_y).narrow(-1, x0, k_x).contiguous()
+        )
+        return pred_c, target_c, mask_c, gt_seg_c
 
     def _compute_malis_weights(
         self,
         pred_aff: torch.Tensor,
         target_aff: torch.Tensor,
         mask: torch.Tensor | None = None,
+        *,
+        gt_seg: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pred_np = pred_aff.to(dtype=torch.float32).cpu().numpy()
         target_np = target_aff.to(dtype=torch.float32).cpu().numpy()
         mask_np = None if mask is None else mask.to(dtype=torch.float32).cpu().numpy()
+        gt_seg_np = None if gt_seg is None else gt_seg.cpu().numpy()
         weights = np.empty_like(pred_np, dtype=np.float32)
         for batch_idx in range(pred_np.shape[0]):
             gt_affs = np.ascontiguousarray(target_np[batch_idx] > 0.5, dtype=np.int32)
@@ -271,11 +324,14 @@ class MalisLoss(nn.Module):
             mask_sample = None
             if mask_np is not None:
                 mask_sample = np.ascontiguousarray(mask_np[batch_idx] == 1, dtype=bool)
-            gt_seg, _ = _malis_lib.connected_components_affgraph(gt_affs, self.nhood)
+            if gt_seg_np is None:
+                gt_seg_sample, _ = _malis_lib.connected_components_affgraph(gt_affs, self.nhood)
+            else:
+                gt_seg_sample = np.ascontiguousarray(gt_seg_np[batch_idx], dtype=np.uint64)
             weights[batch_idx] = self._compute_sample_weights(
                 pred_sample,
                 gt_affs,
-                gt_seg,
+                gt_seg_sample,
                 mask_sample,
             )
 

--- a/connectomics/models/losses/metadata.py
+++ b/connectomics/models/losses/metadata.py
@@ -19,6 +19,7 @@ class LossMetadata:
     call_kind: LossCallKind = "pred_target"  # pred_target | pred_only | pred_pred | unsupported
     target_kind: TargetKind = "dense"  # dense | class_index | none
     spatial_weight_arg: Optional[str] = None  # weight | mask | None
+    gt_seg_arg: Optional[str] = None  # gt_seg | None
 
 
 _LOSS_METADATA_BY_NAME = {
@@ -43,7 +44,7 @@ _LOSS_METADATA_BY_NAME = {
     ),
     "WeightedMSELoss": LossMetadata("WeightedMSELoss", spatial_weight_arg="weight"),
     "WeightedMAELoss": LossMetadata("WeightedMAELoss", spatial_weight_arg="weight"),
-    "MalisLoss": LossMetadata("MalisLoss", spatial_weight_arg="mask"),
+    "MalisLoss": LossMetadata("MalisLoss", spatial_weight_arg="mask", gt_seg_arg="gt_seg"),
     # GAN is not compatible with the generic supervised orchestrator path
     "GANLoss": LossMetadata("GANLoss", call_kind="unsupported", target_kind="none"),
     # Regularization losses

--- a/connectomics/training/lightning/model.py
+++ b/connectomics/training/lightning/model.py
@@ -845,6 +845,7 @@ class ConnectomicsModule(pl.LightningModule):
         stage: str,
         mask: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        gt_seg: Optional[torch.Tensor] = None,
     ):
         """Compute loss handling both standard and deep supervision outputs."""
         loss_orchestrator = self._require_loss_orchestrator()
@@ -853,10 +854,10 @@ class ConnectomicsModule(pl.LightningModule):
         )
         if is_deep_supervision:
             return loss_orchestrator.compute_deep_supervision_loss(
-                outputs, labels, stage=stage, mask=mask, target_mask=target_mask
+                outputs, labels, stage=stage, mask=mask, target_mask=target_mask, gt_seg=gt_seg
             )
         return loss_orchestrator.compute_standard_loss(
-            outputs, labels, stage=stage, mask=mask, target_mask=target_mask
+            outputs, labels, stage=stage, mask=mask, target_mask=target_mask, gt_seg=gt_seg
         )
 
     def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> STEP_OUTPUT:
@@ -868,13 +869,14 @@ class ConnectomicsModule(pl.LightningModule):
         # Binarize mask: (B, 1, D, H, W) float, 1 = valid, 0 = ignore
         mask = (raw_mask > 0).float() if raw_mask is not None else None
         target_mask = batch.get("label_mask", None)
+        gt_seg = batch.get("gt_seg", None)
 
         # Forward pass
         outputs = self(images)
 
         # Compute loss using the loss orchestrator
         total_loss, loss_dict = self._compute_loss(
-            outputs, labels, stage="train", mask=mask, target_mask=target_mask
+            outputs, labels, stage="train", mask=mask, target_mask=target_mask, gt_seg=gt_seg
         )
 
         # Keep full training curves in TensorBoard while avoiding console spam.
@@ -896,13 +898,14 @@ class ConnectomicsModule(pl.LightningModule):
         raw_mask = batch.get("mask", None)
         mask = (raw_mask > 0).float() if raw_mask is not None else None
         target_mask = batch.get("label_mask", None)
+        gt_seg = batch.get("gt_seg", None)
 
         # Forward pass
         outputs = self(images)
 
         # Compute loss using the loss orchestrator
         total_loss, loss_dict = self._compute_loss(
-            outputs, labels, stage="val", mask=mask, target_mask=target_mask
+            outputs, labels, stage="val", mask=mask, target_mask=target_mask, gt_seg=gt_seg
         )
 
         # Compute evaluation metrics if enabled

--- a/connectomics/training/losses/orchestrator.py
+++ b/connectomics/training/losses/orchestrator.py
@@ -481,6 +481,7 @@ class LossOrchestrator:
         is_main_scale: bool,
         mask: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        gt_seg: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Dict[str, float]]:
         if not self.loss_term_specs:
             raise ValueError("Explicit loss term path requested but no loss terms are configured")
@@ -647,6 +648,8 @@ class LossOrchestrator:
                             device=pred_for_loss.device,
                             dtype=pred_for_loss.dtype,
                         )
+                if meta.gt_seg_arg is not None and gt_seg is not None:
+                    extra_loss_kwargs[meta.gt_seg_arg] = gt_seg
                 raw_loss = self._call_with_optional_spatial_weight(
                     loss_fn,
                     pred_for_loss,
@@ -766,6 +769,7 @@ class LossOrchestrator:
         stage: str = "train",
         mask: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        gt_seg: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
         """Compute explicit loss terms for one output scale."""
         loss_dict: Dict[str, float] = {}
@@ -777,6 +781,7 @@ class LossOrchestrator:
             is_main_scale=(scale_idx == 0),
             mask=mask,
             target_mask=target_mask,
+            gt_seg=gt_seg,
         )
         loss_dict.update(explicit_loss_dict)
 
@@ -790,7 +795,13 @@ class LossOrchestrator:
         stage: str = "train",
         mask: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        gt_seg: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        # Deep supervision heads use the legacy CC-recompute path: per-head
+        # gt_seg cannot be downsampled label-correctly alongside DS targets,
+        # so we force the legacy fallback uniformly. See
+        # `.agent/features/malis_gt_passthrough/artifacts/plan_v1.md` §3.
+        gt_seg = None
         main_output = outputs["output"]
         ds_outputs = [outputs[f"ds_{i}"] for i in range(1, 5) if f"ds_{i}" in outputs]
 
@@ -815,7 +826,13 @@ class LossOrchestrator:
         loss_dict: Dict[str, float] = {}
         for scale_idx, (output, ds_weight) in enumerate(zip(all_outputs, ds_weights)):
             scale_loss, scale_loss_dict = self.compute_loss_for_scale(
-                output, labels, scale_idx, stage, mask=mask, target_mask=target_mask
+                output,
+                labels,
+                scale_idx,
+                stage,
+                mask=mask,
+                target_mask=target_mask,
+                gt_seg=gt_seg,
             )
             total_loss += scale_loss * ds_weight
             loss_dict.update(scale_loss_dict)
@@ -830,6 +847,7 @@ class LossOrchestrator:
         stage: str = "train",
         mask: Optional[torch.Tensor] = None,
         target_mask: Optional[torch.Tensor] = None,
+        gt_seg: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
         total_loss, loss_dict = self._compute_explicit_terms_for_output(
             outputs,
@@ -839,6 +857,7 @@ class LossOrchestrator:
             is_main_scale=True,
             mask=mask,
             target_mask=target_mask,
+            gt_seg=gt_seg,
         )
         loss_dict[f"{stage}_loss_total"] = total_loss.item()
         return total_loss, loss_dict

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -122,6 +122,7 @@ Documentation
    notes/installation
    notes/config
    notes/dataloading
+   notes/malis
    notes/faq
 
 .. toctree::

--- a/docs/source/notes/malis.rst
+++ b/docs/source/notes/malis.rst
@@ -1,0 +1,188 @@
+MALIS Loss
+==========
+
+The ``MalisLoss`` (`connectomics.models.losses.malis.MalisLoss`) is a
+constrained structured loss for 3D affinity prediction, used as a
+companion term to per-channel BCE in neuron-segmentation configs such
+as ``tutorials/neuron_nisb/base_banis+_malis.yaml``.
+
+This page documents two knobs that significantly affect performance
+and correctness:
+
+- ``malis_crop_size`` — random sub-volume crop on the MALIS forward.
+- ``label_transform.emit_gt_seg`` — pass the eroded GT segmentation
+  through to MalisLoss to skip the per-step connected-components
+  call and to preserve global instance IDs under cropping.
+
+The Cost of Full-Volume MALIS
+-----------------------------
+
+MALIS computes per-edge weights via two maximin-tree passes over the
+affinity graph; for each sample these passes are single-threaded
+CPU work that the GPU forward/backward path waits on. On the BANIS
+production config (MedNeXt-L, batch 2, 128³ patch), the cost is large:
+
+.. list-table:: BANIS production config — measured step rate
+   :header-rows: 1
+
+   * - Configuration
+     - Run
+     - it/s
+     - sec/step
+     - h/epoch (5000 steps)
+   * - BCE only (no MALIS)
+     - slurm 2442858 / 2442857
+     - ~0.71
+     - ~1.4
+     - ~1.95
+   * - Full-volume MALIS (original)
+     - slurm 2487040
+     - ~0.17
+     - ~5.9
+     - ~7.3
+   * - MALIS with ``malis_crop_size: 64``
+     - slurm 2505814
+     - ~0.78
+     - ~1.3
+     - ~1.78
+
+The "Full-volume MALIS" row is the original implementation. Adding
+MALIS makes each epoch ~3.5× slower than BCE-only on this hardware.
+
+``malis_crop_size`` — Random Sub-Volume Crop
+--------------------------------------------
+
+Setting ``malis_crop_size: K`` (or ``[Kz, Ky, Kx]``) instructs
+MalisLoss to apply a single random ``K × K × K`` crop to ``pred``,
+``target``, and ``mask`` on each forward call before computing MALIS.
+The crop origin is shared across the batch and resampled every step,
+so over many iterations the model still sees MALIS supervision
+covering the whole patch in expectation.
+
+The reduction in MALIS volume is **cubic in the crop ratio**. At
+``K = 64`` on a ``128³`` patch the cropped volume is ``1/8`` of the
+original, and CPU MALIS work drops by roughly the same factor.
+
+YAML usage:
+
+.. code-block:: yaml
+
+    model:
+      loss:
+        losses:
+          - function: PerChannelBCEWithLogitsLoss
+            weight: 1.0
+            kwargs: { auto_pos_weight: true, max_pos_weight: 10.0 }
+          - function: MalisLoss
+            weight: 1.0
+            pred_slice: "0:3"
+            target_slice: "0:3"
+            kwargs:
+              nhood: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+              sigmoid: true
+              reduction: mean
+              malis_crop_size: 64   # or e.g. [32, 64, 64] for anisotropic
+
+Default ``malis_crop_size: null`` (or omitting the key) preserves
+the original full-volume behavior bit-for-bit.
+
+**Measured speedup vs original (slurm 2505814 vs 2487040):**
+
+- it/s: 0.17 → 0.78 — **~4.6× faster per step**.
+- hours/epoch (5000 steps): 7.3 → 1.78 — **~4.1× faster wall-clock**.
+- Total training (200 k steps, 40 epochs at 5000/epoch): ~12 days →
+  ~3 days.
+
+**Caveat.** Cropping reduces the spatial volume MalisLoss sees per
+step. The model is still trained on the full patch by the BCE term,
+but the structured MALIS signal is restricted to the cropped sub-volume
+on each step. Convergence behaviour on your dataset should be
+validated empirically before committing to a final crop size.
+
+``emit_gt_seg`` — Skip the Per-Step CC, Fix Cropped Topology
+------------------------------------------------------------
+
+Without ``emit_gt_seg``, MalisLoss reconstructs the GT segmentation
+from the GT affinity tensor each step:
+
+.. code-block:: text
+
+    gt_seg = connected_components_affgraph(target > 0.5, nhood)
+
+This is wasteful (the data pipeline already produced the segmentation
+upstream), but more importantly it interacts badly with
+``malis_crop_size``: when a single GT instance spans the crop boundary,
+the CC of the cropped affinities labels its pieces as **distinct
+components**, and MALIS then injects spurious negative-constraint
+edges inside one true instance.
+
+Setting ``label_transform.emit_gt_seg: true`` adds a small
+``CopyItemsd`` MONAI transform immediately after the existing
+``SegErosionInstanced`` step, snapshotting the post-augmentation,
+post-erosion segmentation as ``batch["gt_seg"]``. The loss
+orchestrator forwards it to MalisLoss, which:
+
+- Skips the per-step ``connected_components_affgraph`` call.
+- Crops the supplied ``gt_seg`` at the same origin as ``pred`` /
+  ``target`` / ``mask``, preserving each instance's global label
+  inside the crop window.
+
+YAML usage:
+
+.. code-block:: yaml
+
+    default:
+      data:
+        label_transform:
+          erosion: 2
+          emit_gt_seg: true   # opt-in; pairs with MalisLoss
+
+Default ``emit_gt_seg: false`` preserves the legacy CC-recompute
+behavior bit-for-bit; configs without MalisLoss are unaffected.
+
+**Deep supervision.** When deep supervision is active, the loss
+orchestrator forces ``gt_seg=None`` for every head (DS lower heads
+work on downsampled targets that ``gt_seg`` cannot match
+label-correctly with the same cheap transform). MalisLoss in a DS
+config falls back to the CC-recompute path; the BANIS production
+configs use ``deep_supervision: false`` and are unaffected.
+
+Combined Speedup
+----------------
+
+Both knobs compose cleanly. The crop is the dominant speedup; the
+``gt_seg`` passthrough adds a small additional CPU saving (~5–10 % of
+the remaining MALIS overhead — the per-step CC is removed but the
+two maximin-tree passes still dominate) on top of correctness.
+
+.. list-table:: Cumulative impact relative to the original
+   :header-rows: 1
+
+   * - Configuration
+     - Speedup vs original
+     - Correctness fix
+   * - Full-volume MALIS (original)
+     - 1.0×
+     - —
+   * - ``malis_crop_size: 64``
+     - ~4.6× (measured)
+     - —
+   * - ``malis_crop_size: 64`` + ``emit_gt_seg: true``
+     - ~4.6× plus a few % (estimated)
+     - Preserves global instance IDs under crop;
+       removes spurious negative-constraint edges
+       at cropped instance boundaries.
+
+The correctness fix is the primary motivation for
+``emit_gt_seg``; the speed benefit is secondary.
+
+See Also
+--------
+
+- ``tutorials/neuron_nisb/base_banis+_malis.yaml`` — production
+  config with both knobs enabled.
+- ``lib/malis/INVESTIGATION.md`` — internal notes on GPU MALIS
+  candidates and algorithm-level speedups beyond what this PR
+  ships.
+- The MalisLoss reference: Turaga *et al.*, *Maximin learning of
+  image segmentation*, NIPS 2009.

--- a/tests/integration/test_affinity_cc3d.py
+++ b/tests/integration/test_affinity_cc3d.py
@@ -109,6 +109,7 @@ class TestAffinityCC3D:
         ), f"Expected 3 labels (bg + 2 objects), got {len(unique_labels)}"
         assert 0 in unique_labels, "Background label 0 should be present"
 
+    @pytest.mark.skipif(not NUMBA_AVAILABLE, reason="numba required")
     def test_threshold_sensitivity(self, simple_affinities):
         """Test that threshold parameter affects segmentation."""
         # Low threshold - more connected

--- a/tests/test_decode_waterz.py
+++ b/tests/test_decode_waterz.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from connectomics.decoding.decoders import waterz as waterz_decoder
+
+# decode_waterz calls into the real waterz package (waterz._uint8,
+# merge_function_to_scoring); the fakes below only stub waterz.waterz(). Skip
+# the whole module when waterz is not installed (e.g. minimal CI).
+pytest.importorskip("waterz")
 
 
 class _FakeWaterzModule:

--- a/tests/test_decode_waterz.py
+++ b/tests/test_decode_waterz.py
@@ -60,10 +60,25 @@ def test_decode_waterz_skips_dust_when_disabled(monkeypatch):
 
 
 def test_decode_waterz_reuses_agglomeration_graph_for_dust(monkeypatch):
-    """Dust merge reuses agglomeration's region graph with inverted OneMinus scores."""
+    """Dust merge reuses agglomeration's region graph via dust_merge_from_region_graph."""
     fake_waterz = _FakeWaterzModule()
     monkeypatch.setattr(waterz_decoder, "waterz", fake_waterz)
     monkeypatch.setattr(waterz_decoder, "WATERZ_AVAILABLE", True)
+
+    dust_calls = []
+
+    def fake_dust_merge(seg, region_graph, **kwargs):
+        dust_calls.append(
+            {
+                "seg_shape": seg.shape,
+                "region_graph": region_graph,
+                "size_th": kwargs.get("size_th"),
+                "weight_th": kwargs.get("weight_th"),
+                "dust_th": kwargs.get("dust_th"),
+            }
+        )
+
+    monkeypatch.setattr(waterz_decoder, "dust_merge_from_region_graph", fake_dust_merge)
 
     waterz_decoder.decode_waterz(
         np.ones((3, 4, 4, 4), dtype=np.float32),
@@ -75,13 +90,11 @@ def test_decode_waterz_reuses_agglomeration_graph_for_dust(monkeypatch):
     )
 
     assert fake_waterz.waterz_calls[0]["return_region_graph"] is True
-    assert len(fake_waterz.merge_segments_calls) == 1
-    call = fake_waterz.merge_segments_calls[0]
+    assert len(dust_calls) == 1
+    call = dust_calls[0]
     assert call["seg_shape"] == (4, 4, 4)
-    assert call["rg_affs"] == [0.800000011920929]  # 1.0 - 0.2
-    assert call["id1"] == [1]
-    assert call["id2"] == [2]
-    assert call["counts"] == [0, 32, 32]
+    # Region graph is forwarded as-is from agglomeration (OneMinus scores).
+    assert call["region_graph"] == [{"u": 1, "v": 2, "score": 0.2}]
     assert call["size_th"] == 100
     assert call["weight_th"] == 0.3
     assert call["dust_th"] == 50

--- a/tests/unit/test_connectomics_module.py
+++ b/tests/unit/test_connectomics_module.py
@@ -92,7 +92,9 @@ def test_training_step_uses_deep_supervision_branch():
 
     branch_called = {"used": False}
 
-    def fake_deep_supervision(outputs, labels, stage="train", mask=None, target_mask=None):
+    def fake_deep_supervision(
+        outputs, labels, stage="train", mask=None, target_mask=None, gt_seg=None
+    ):
         branch_called["used"] = True
         return torch.tensor(0.0, requires_grad=True), {"train_loss_total": 0.0}
 

--- a/tests/unit/test_data_factory.py
+++ b/tests/unit/test_data_factory.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
-from monai.transforms import Compose, Resized
+import torch
+from monai.transforms import Compose, CopyItemsd, Resized
 
 from connectomics.config import Config
 from connectomics.config.pipeline.config_io import resolve_data_paths
-from connectomics.data.augmentation.build import build_test_transforms, build_val_transforms
+from connectomics.data.augmentation.build import (
+    build_test_transforms,
+    build_train_transforms,
+    build_val_transforms,
+)
 from connectomics.data.augmentation.transforms import ResizeByFactord
+from connectomics.data.processing.transforms import SegErosionInstanced
 from connectomics.training.lightning.data_factory import create_datamodule
 
 
@@ -47,6 +54,56 @@ def test_build_val_transforms_uses_data_transform_resize_with_expected_modes():
     assert resize_transforms[0].mode == ("bilinear",)
     assert resize_transforms[1].keys == ("label", "mask")
     assert resize_transforms[1].mode == ("nearest", "nearest")
+
+
+def _cfg_with_gt_seg_label_transform() -> Config:
+    cfg = Config()
+    cfg.data.image_transform.normalize = "none"
+    cfg.data.label_transform.erosion = 2
+    cfg.data.label_transform.emit_gt_seg = True
+    cfg.data.label_transform.targets = [
+        {
+            "name": "affinity",
+            "kwargs": {
+                "offsets": ["1-0-0", "0-1-0", "0-0-1"],
+                "affinity_mode": "banis",
+            },
+        }
+    ]
+    return cfg
+
+
+def test_emit_gt_seg_inserts_copy_after_erosion_train_and_val():
+    cfg = _cfg_with_gt_seg_label_transform()
+
+    for build_fn in (build_train_transforms, build_val_transforms):
+        transforms = build_fn(cfg, keys=["image", "label"], skip_loading=True).transforms
+        erosion_idx = next(
+            i for i, t in enumerate(transforms) if isinstance(t, SegErosionInstanced)
+        )
+        copy_idx = next(i for i, t in enumerate(transforms) if isinstance(t, CopyItemsd))
+
+        assert copy_idx == erosion_idx + 1
+        assert transforms[copy_idx].keys == ("label",)
+        assert transforms[copy_idx].names == ("gt_seg",)
+
+
+def test_emit_gt_seg_runtime_end_to_end_train_transform():
+    cfg = _cfg_with_gt_seg_label_transform()
+    transforms = build_train_transforms(cfg, keys=["image", "label"], skip_loading=True)
+
+    label = np.zeros((1, 6, 8, 8), dtype=np.uint64)
+    label[:, 1:5, 2:6, 2:6] = 7
+    label[:, 2:4, 3:5, 3:5] = 9
+    expected = SegErosionInstanced(keys=["label"], tsz_h=2)({"label": label.copy()})["label"]
+
+    out = transforms({"image": np.zeros_like(label, dtype=np.float32), "label": label})
+
+    assert "gt_seg" in out
+    np.testing.assert_array_equal(np.asarray(out["gt_seg"]), expected)
+    assert np.asarray(out["gt_seg"]).shape == label.shape
+    assert isinstance(out["label"], torch.Tensor)
+    assert tuple(out["label"].shape) == (3, 6, 8, 8)
 
 
 def test_build_test_transforms_derives_scale_factors_from_patch_resize():

--- a/tests/unit/test_data_factory_zarr_aux.py
+++ b/tests/unit/test_data_factory_zarr_aux.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from connectomics.config import Config
 from connectomics.data.io import save_volume
@@ -8,6 +9,7 @@ from connectomics.training.lightning.data_factory import _maybe_precompute_label
 
 
 def test_maybe_precompute_label_aux_reuses_existing_zarr_cache(monkeypatch, tmp_path: Path):
+    pytest.importorskip("zarr")
     label_path = tmp_path / "data.zarr" / "seg"
     aux_path = tmp_path / "data.zarr" / "seg_skeleton"
     save_volume(str(label_path), np.zeros((2, 2, 2), dtype=np.uint16), file_format="zarr")

--- a/tests/unit/test_decode_abiss_wrapper.py
+++ b/tests/unit/test_decode_abiss_wrapper.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 from connectomics.decoding import decode_abiss
+
+# The relative-script test below shells out to scripts/run_abiss_single.py, which
+# requires the compiled ABISS `ws` binary (lib/abiss/build/ws or on PATH). That
+# binary is absent in minimal installs (e.g. CI), so guard that test on it.
+_WS_BINARY = Path(__file__).resolve().parents[2] / "lib" / "abiss" / "build" / "ws"
+_ABISS_WS_AVAILABLE = _WS_BINARY.exists() or shutil.which("ws") is not None
 
 
 def test_decode_abiss_with_list_command_writes_npy_output():
@@ -61,6 +69,7 @@ def test_decode_abiss_raises_if_output_missing():
         decode_abiss(pred, command=command)
 
 
+@pytest.mark.skipif(not _ABISS_WS_AVAILABLE, reason="ABISS ws binary not built (lib/abiss/build/ws)")
 def test_decode_abiss_with_relative_script_command_outside_repo_cwd(monkeypatch, tmp_path):
     pred = np.zeros((3, 6, 8, 10), dtype=np.float32)
     pred[:, 1:5, 2:7, 3:9] = 1.0

--- a/tests/unit/test_decode_waterz.py
+++ b/tests/unit/test_decode_waterz.py
@@ -7,6 +7,11 @@ import pytest
 
 from connectomics.decoding.decoders import waterz as waterz_decoder
 
+# decode_waterz calls into the real waterz package (waterz._uint8,
+# merge_function_to_scoring); the fakes below only stub waterz.waterz(). Skip
+# the whole module when waterz is not installed (e.g. minimal CI).
+pytest.importorskip("waterz")
+
 
 class _FakeWaterzModule:
     """Minimal waterz stub for testing wrapper behavior."""

--- a/tests/unit/test_loss_orchestrator.py
+++ b/tests/unit/test_loss_orchestrator.py
@@ -62,6 +62,33 @@ class NoWeightSpyLoss(nn.Module):
         return (pred - target).abs().mean()
 
 
+class GtSegSpyLoss(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+        self._connectomics_loss_metadata = LossMetadata(
+            name="GtSegSpyLoss",
+            call_kind="pred_target",
+            target_kind="dense",
+            gt_seg_arg="gt_seg",
+        )
+
+    def forward(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        gt_seg: torch.Tensor = None,
+    ):
+        self.calls.append(
+            {
+                "gt_seg": gt_seg,
+                "pred_shape": tuple(pred.shape),
+                "target_shape": tuple(target.shape),
+            }
+        )
+        return (pred - target).abs().mean()
+
+
 class _CrossEntropySpyBase(nn.Module):
     def __init__(self):
         super().__init__()
@@ -209,6 +236,63 @@ def test_standard_loss_uses_pos_weight_only_for_weight_aware_losses():
     received_weight = weighted_loss.calls[0]["weight"]
     assert received_weight is not None
     assert torch.equal(received_weight, _expected_pos_weight(labels))
+
+
+def test_orchestrator_passes_gt_seg_when_metadata_declares_it():
+    spy_loss = GtSegSpyLoss()
+    orchestrator = LossOrchestrator(
+        cfg=_cfg(losses=[{"weight": 1.0}]),
+        loss_functions=nn.ModuleList([spy_loss]),
+        loss_weights=[1.0],
+        enable_nan_detection=False,
+        debug_on_nan=False,
+    )
+
+    outputs = torch.zeros(1, 1, 2, 2, 2)
+    labels = torch.ones_like(outputs)
+    gt_seg = torch.ones(1, 2, 2, 2, dtype=torch.int64)
+
+    total_loss, loss_dict = orchestrator.compute_standard_loss(
+        outputs,
+        labels,
+        stage="train",
+        gt_seg=gt_seg,
+    )
+
+    assert torch.isfinite(total_loss)
+    assert "train_loss_total" in loss_dict
+    assert len(spy_loss.calls) == 1
+    assert spy_loss.calls[0]["gt_seg"] is gt_seg
+
+
+def test_orchestrator_does_not_pass_gt_seg_in_deep_supervision():
+    spy_loss = GtSegSpyLoss()
+    orchestrator = LossOrchestrator(
+        cfg=_cfg(losses=[{"weight": 1.0, "apply_deep_supervision": True}]),
+        loss_functions=nn.ModuleList([spy_loss]),
+        loss_weights=[1.0],
+        enable_nan_detection=False,
+        debug_on_nan=False,
+    )
+
+    outputs = {
+        "output": torch.zeros(1, 1, 2, 2, 2),
+        "ds_1": torch.zeros(1, 1, 2, 2, 2),
+    }
+    labels = torch.ones(1, 1, 2, 2, 2)
+    gt_seg = torch.ones(1, 2, 2, 2, dtype=torch.int64)
+
+    total_loss, loss_dict = orchestrator.compute_deep_supervision_loss(
+        outputs,
+        labels,
+        stage="train",
+        gt_seg=gt_seg,
+    )
+
+    assert torch.isfinite(total_loss)
+    assert "train_loss_total" in loss_dict
+    assert len(spy_loss.calls) == 2
+    assert all(call["gt_seg"] is None for call in spy_loss.calls)
 
 
 def test_pred_target_defaults_to_all_channels_when_slices_omitted():

--- a/tests/unit/test_malis_loss.py
+++ b/tests/unit/test_malis_loss.py
@@ -1,7 +1,7 @@
 """Tests for MalisLoss wrapper around lib/malis."""
 
-from contextlib import contextmanager
 import unittest
+from contextlib import contextmanager
 
 import numpy as np
 import torch
@@ -88,6 +88,14 @@ def _fixed_torch_randint(value: int):
         torch.randint = original_randint
 
 
+class TestMalisLossMetadata(unittest.TestCase):
+    def test_malis_metadata_has_gt_seg_arg(self):
+        from connectomics.models.losses.metadata import get_loss_metadata
+
+        meta = get_loss_metadata("MalisLoss")
+        self.assertEqual(meta.gt_seg_arg, "gt_seg")
+
+
 @unittest.skipUnless(_HAS_MALIS, "malis extension not built")
 class TestMalisLoss(unittest.TestCase):
     def _crop_loss_shape(self, crop_size):
@@ -111,6 +119,7 @@ class TestMalisLoss(unittest.TestCase):
         self.assertIsNotNone(meta)
         self.assertEqual(meta.name, "MalisLoss")
         self.assertEqual(meta.spatial_weight_arg, "mask")
+        self.assertEqual(meta.gt_seg_arg, "gt_seg")
         self.assertIsInstance(loss_fn, MalisLoss)
 
     def test_not_in_package_namespace(self):
@@ -180,6 +189,151 @@ class TestMalisLoss(unittest.TestCase):
             rtol=1e-5,
             atol=1e-6,
         )
+
+    def test_malis_gt_seg_equivalent_to_cc_on_uncropped(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(0)
+        loss_fn = MalisLoss(sigmoid=False)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        gt_seg = np.zeros((5, 6, 7), dtype=np.uint64)
+        gt_seg[:, :3, :] = 1
+        gt_seg[:, 3:, :] = 2
+        target_np = _malis_lib.seg_to_affgraph(gt_seg.astype(np.int32), nhood).astype(np.float32)
+        gt_affs = np.ascontiguousarray(target_np > 0.5, dtype=np.int32)
+        cc_seg, _ = _malis_lib.connected_components_affgraph(gt_affs, nhood)
+
+        target = torch.from_numpy(target_np).unsqueeze(0)
+        pred_a = torch.rand(1, C, 5, 6, 7, requires_grad=True)
+        pred_b = pred_a.detach().clone().requires_grad_(True)
+        supplied = torch.from_numpy(cc_seg).unsqueeze(0)
+
+        loss_a = loss_fn(pred_a, target)
+        loss_b = loss_fn(pred_b, target, gt_seg=supplied)
+        loss_a.backward()
+        loss_b.backward()
+
+        torch.testing.assert_close(loss_b, loss_a, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(pred_b.grad, pred_a.grad, rtol=1e-5, atol=1e-6)
+
+    def test_malis_gt_seg_none_preserves_legacy_path(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(1)
+        loss_fn = MalisLoss(sigmoid=False)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        gt_seg = np.zeros((4, 5, 6), dtype=np.int32)
+        gt_seg[:, :2, :] = 1
+        gt_seg[:, 2:, :] = 2
+        target_np = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        target = torch.from_numpy(target_np).unsqueeze(0)
+        pred_a = torch.rand(1, C, 4, 5, 6, requires_grad=True)
+        pred_b = pred_a.detach().clone().requires_grad_(True)
+
+        loss_a = loss_fn(pred_a, target)
+        loss_b = loss_fn(pred_b, target, gt_seg=None)
+        loss_a.backward()
+        loss_b.backward()
+
+        torch.testing.assert_close(loss_b, loss_a, rtol=0.0, atol=0.0)
+        torch.testing.assert_close(pred_b.grad, pred_a.grad, rtol=0.0, atol=0.0)
+
+    def test_malis_gt_seg_crop_fixes_instance_fragmentation(self):
+        from connectomics.models.losses import malis as malis_mod
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(2)
+        loss_fn = MalisLoss(malis_crop_size=6, sigmoid=False)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        gt_seg = np.zeros((8, 8, 8), dtype=np.uint64)
+        gt_seg[0:6, 3, 2] = 1
+        gt_seg[0:6, 3, 5] = 1
+        gt_seg[0, 3, 2:6] = 1
+        target_np = _malis_lib.seg_to_affgraph(gt_seg.astype(np.int32), nhood).astype(np.float32)
+        target = torch.from_numpy(target_np).unsqueeze(0)
+        pred = torch.rand(1, C, 8, 8, 8)
+
+        recorded_cc: list[np.ndarray] = []
+        real_cc = _malis_lib.connected_components_affgraph
+
+        def _spy(aff_in, nh_in):
+            cc_seg, count = real_cc(aff_in, nh_in)
+            recorded_cc.append(np.array(cc_seg, copy=True))
+            return cc_seg, count
+
+        orig_cc = malis_mod._malis_lib.connected_components_affgraph
+        malis_mod._malis_lib.connected_components_affgraph = _spy
+        try:
+            with _fixed_torch_randint(1):
+                loss_legacy = loss_fn(pred, target)
+        finally:
+            malis_mod._malis_lib.connected_components_affgraph = orig_cc
+
+        self.assertEqual(len(recorded_cc), 1)
+        legacy_fg = np.unique(recorded_cc[0][recorded_cc[0] > 0])
+        self.assertGreaterEqual(len(legacy_fg), 2)
+
+        cropped_supplied = gt_seg[1:7, 1:7, 1:7]
+        supplied_fg = np.unique(cropped_supplied[cropped_supplied > 0])
+        self.assertEqual(len(supplied_fg), 1)
+
+        recorded_passthrough: list[np.ndarray] = []
+
+        def _unexpected_spy(aff_in, nh_in):
+            cc_seg, count = real_cc(aff_in, nh_in)
+            recorded_passthrough.append(np.array(cc_seg, copy=True))
+            return cc_seg, count
+
+        malis_mod._malis_lib.connected_components_affgraph = _unexpected_spy
+        try:
+            with _fixed_torch_randint(1):
+                loss_passthrough = loss_fn(
+                    pred,
+                    target,
+                    gt_seg=torch.from_numpy(gt_seg).unsqueeze(0),
+                )
+        finally:
+            malis_mod._malis_lib.connected_components_affgraph = orig_cc
+
+        self.assertEqual(len(recorded_passthrough), 0)
+        self.assertFalse(torch.isclose(loss_legacy, loss_passthrough, rtol=1e-6, atol=1e-7).item())
+
+    def test_malis_gt_seg_shape_validation(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        loss_fn = MalisLoss(sigmoid=False)
+        C = loss_fn.nhood.shape[0]
+        pred = torch.zeros(1, C, 4, 4, 4)
+        target = torch.zeros_like(pred)
+        gt_seg = torch.zeros(1, 4, 4, 5, dtype=torch.int64)
+
+        with self.assertRaises(ValueError):
+            loss_fn(pred, target, gt_seg=gt_seg)
+
+    def test_malis_gt_seg_no_grad_through_seg(self):
+        from connectomics.models.losses.malis import MalisLoss
+
+        torch.manual_seed(3)
+        loss_fn = MalisLoss(sigmoid=False)
+        nhood = loss_fn.nhood
+        C = nhood.shape[0]
+        gt_seg = np.zeros((4, 5, 6), dtype=np.int32)
+        gt_seg[:, :3, :] = 1
+        gt_seg[:, 3:, :] = 2
+        target_np = _malis_lib.seg_to_affgraph(gt_seg, nhood).astype(np.float32)
+        pred = torch.rand(1, C, 4, 5, 6, requires_grad=True)
+        target = torch.from_numpy(target_np).unsqueeze(0)
+        supplied = torch.from_numpy(gt_seg).unsqueeze(0)
+
+        self.assertFalse(supplied.requires_grad)
+        loss = loss_fn(pred, target, gt_seg=supplied)
+        loss.backward()
+
+        self.assertIsNotNone(pred.grad)
+        self.assertTrue(torch.isfinite(pred.grad).all().item())
 
     def test_reduction_default_and_supported_modes(self):
         from connectomics.models.losses.malis import MalisLoss

--- a/tests/unit/test_optuna_tuner.py
+++ b/tests/unit/test_optuna_tuner.py
@@ -562,6 +562,7 @@ def test_batch_trial_payload_applies_spatial_transpose():
 
 
 def test_objective_returns_bad_value_when_standard_trial_times_out(monkeypatch):
+    pytest.importorskip("optuna")
     cfg = Config()
     cfg.tune = TuneConfig()
     cfg.tune.trial_timeout = 12
@@ -588,6 +589,7 @@ def test_objective_returns_bad_value_when_standard_trial_times_out(monkeypatch):
 
 
 def test_objective_returns_bad_value_when_waterz_batch_trial_times_out(monkeypatch):
+    pytest.importorskip("optuna")
     cfg = Config()
     cfg.tune = TuneConfig()
     cfg.tune.trial_timeout = 30

--- a/tests/unit/test_test_pipeline_multi_volume_eval.py
+++ b/tests/unit/test_test_pipeline_multi_volume_eval.py
@@ -181,6 +181,7 @@ def test_run_evaluation_stage_accepts_plain_context_and_arrays():
 
 
 def test_compute_test_metrics_supports_nerl_without_dense_labels(tmp_path):
+    pytest.importorskip("em_erl")
     ERLGraph, _, _ = import_em_erl()
     graph_path = tmp_path / "gt_graph.npz"
     graph = ERLGraph(
@@ -233,6 +234,7 @@ def test_compute_test_metrics_supports_nerl_without_dense_labels(tmp_path):
 
 
 def test_compute_test_metrics_supports_banis_skeleton_pickle(tmp_path):
+    pytest.importorskip("em_erl")
     nx = pytest.importorskip("networkx")
     import pickle
 

--- a/tests/unit/test_v3_guardrails.py
+++ b/tests/unit/test_v3_guardrails.py
@@ -173,6 +173,7 @@ def test_connectomics_inference_public_api_snapshot():
         "write_prediction_artifact_attrs",
         "run_prediction_inference",
         "is_chunked_inference_enabled",
+        "is_external_chunk_sharding_enabled",
         "run_chunked_prediction_inference",
         "apply_prediction_transform",
         "apply_storage_dtype_transform",

--- a/tutorials/neuron_nisb/base_banis+_malis.yaml
+++ b/tutorials/neuron_nisb/base_banis+_malis.yaml
@@ -11,6 +11,9 @@ description: >-
 save_path: outputs/nisb_base_banis_v3_erosion2_malis
 
 default:
+  data:
+    label_transform:
+      emit_gt_seg: true
   model:
     loss:
       # YAML list overrides are replace-not-merge, so the v1 base's
@@ -30,4 +33,4 @@ default:
             nhood: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
             sigmoid: true
             reduction: mean
-            # malis_crop_size: 64  # symmetric; or e.g. [32, 64, 64] for asymmetric. See lib/malis/INVESTIGATION.md.
+            malis_crop_size: 64  # enabled; ~4.6x step speedup vs full-volume MALIS (smoke test 2505814)


### PR DESCRIPTION
## Summary

Passes the eroded GT segmentation from the data pipeline through to `MalisLoss` so it can:

1. **Skip its internal `connected_components_affgraph(gt_affs, nhood)` call** every training step (~5–10 % of MALIS step cost; small).
2. **Preserve global instance IDs under `malis_crop_size`** (the primary motivation; fixes a correctness artifact in the prior crop PR).

Opt-in via `label_transform.emit_gt_seg: true` on the YAML side; default off → bit-for-bit identical to current behaviour for configs without it.

## Why

With `malis_crop_size` enabled (#crop PR), the current MALIS path runs CC on the **cropped** `gt_affs`. When a single GT instance spans the crop boundary so that two of its pieces appear inside the crop but are not connected within that window, CC labels them as **distinct components**. MALIS then injects spurious negative-constraint edges inside one true instance.

Passing the eroded `gt_seg` from upstream (where global instance IDs are preserved) and cropping it with the same origin fixes this.

## Speedup story (measured + documented)

Production config: MedNeXt-L, batch 2, 128³ patch on L40S.

| Configuration                              | it/s | sec/step | h/epoch (5000 steps) | Speedup vs original |
|--------------------------------------------|------|----------|----------------------|---------------------|
| BCE only (no MALIS)                        | ~0.71| ~1.4     | ~1.95                | — (reference)       |
| Full-volume MALIS (original)               | ~0.17| ~5.9     | ~7.3                 | 1.0×                |
| MALIS + `malis_crop_size: 64`              | ~0.78| ~1.3     | ~1.78                | **~4.6×**           |
| MALIS + crop + `emit_gt_seg: true`         | ~0.78+| ~1.3    | ~1.78                | ~4.6× plus a few %  |

- Crop alone gives ~4.6× speedup vs the original full-volume MALIS (slurm 2505814 vs 2487040).
- `emit_gt_seg` adds a small additional speedup AND is primarily a **correctness fix** for the cropped case.

See `docs/source/notes/malis.rst` (new) and the `MalisLoss` class docstring for the full table.

## Implementation

### Data-pipeline boundary

- `LabelTransformConfig.emit_gt_seg: bool = False` (strict dataclass field).
- `CopyItemsd(keys="label", names="gt_seg")` inserted in `connectomics/data/augmentation/build.py` immediately after `SegErosionInstanced` (both train and val), gated by `label_cfg.emit_gt_seg`. Makes "post-augment, post-erode" the canonical snapshot point.
- `MultiTaskLabelTransformd` is untouched.

### Loss orchestrator

- `LossMetadata.gt_seg_arg: Optional[str]`. Set to `"gt_seg"` for `MalisLoss`; all other losses unaffected.
- `compute_standard_loss(..., gt_seg=None)` plumbs the batch's `gt_seg` to any term whose metadata declares the arg, via the existing `extra_loss_kwargs` extension point.
- `compute_deep_supervision_loss(..., gt_seg=None)` forces `gt_seg = None` for every head — DS lower heads work on downsampled targets that `gt_seg` can't match label-correctly. MalisLoss + DS falls back to the legacy CC-recompute path. Test-pinned.

### MalisLoss

- `forward(pred, target, mask=None, gt_seg=None)` accepts the optional kwarg.
- `_prepare_gt_seg` normalizes shape (accepts `[B, Z, Y, X]` and `[B, 1, Z, Y, X]`), validates against pred spatial dims.
- `_apply_crop_if_configured` now returns a 4-tuple and crops `gt_seg` at the same origin as pred/target/mask.
- `_compute_malis_weights(..., *, gt_seg=None)` uses the supplied seg per sample when provided; falls back to `connected_components_affgraph` otherwise.

### YAML (`tutorials/neuron_nisb/base_banis+_malis.yaml`)

```yaml
default:
  data:
    label_transform:
      emit_gt_seg: true   # opt-in; pairs with MalisLoss
  ...
            malis_crop_size: 64
```

## Tests

`python -m pytest tests/unit/test_malis_loss.py tests/unit/test_data_factory.py tests/unit/test_loss_orchestrator.py -q` → **76 passed, 1 skipped**.

- `test_malis_loss.py` — 6 new tests:
  - Metadata declares `gt_seg_arg`.
  - Uncropped CC equivalence (`gt_seg` supplied vs reconstructed match within `rtol=1e-5`).
  - `gt_seg=None` strict-equality preservation of the legacy path.
  - **Cropped-instance-fragmentation bug fix:** Path A spies on `connected_components_affgraph` and asserts the CC labels fragment; Path B asserts CC was NOT called and the supplied gt_seg retains a single instance label; losses differ.
  - Shape validation (`ValueError` on mismatch).
  - No grad flows through `gt_seg`.
- `test_data_factory.py` — 2 new tests for the `CopyItemsd` insertion (train + val symmetry, plus a runtime end-to-end equivalence to a manual erosion).
- `test_loss_orchestrator.py` — 2 new tests pinning the standard-loss `gt_seg` plumbing and the DS=legacy fallback.

## Docs

- New `docs/source/notes/malis.rst` covering MALIS performance and correctness knobs (linked from `docs/source/index.rst` "Get Started" toctree).
- `MalisLoss` class docstring extended with a Performance section citing the measured speedup.

## Backward compatibility

- Default behaviour (no `emit_gt_seg`) is bit-for-bit identical to current `MalisLoss`.
- Configs without MALIS are completely unaffected.
- Deep-supervision configs are unaffected (orchestrator forces legacy CC fallback when DS is on).

## CCC design history

Under `.agent/features/malis_gt_passthrough/` in the worktree (gitignored). Plan rounds: 2 (plan_v0 NEEDS_CHANGES → plan_v1 APPROVE_WITH_MINOR_COMMENTS). Code rounds: 1 (code_v0 → review_v0 APPROVE_WITH_MINOR_COMMENTS). 3 minor review_v0 findings were applied as small follow-up commits or kept as observational (see review_v0 artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
